### PR TITLE
Convert notebook pipeline into Python scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker build -t eegemg-pipeline .
 
 2. Prepare a config file (see `pipeline.config.example.json`).
 
-3. Run all notebooks in sequence with a single command
+3. Run all steps in sequence with a single command
 
 ```bash
 # Mount your data directory and config into the container
@@ -32,7 +32,13 @@ docker run --rm \
   eegemg-pipeline --config /config/pipeline.json
 ```
 
-Executed notebooks are saved in `executed_notebooks/` for debugging.
+The pipeline now executes pure Python scripts (no notebook dependency):
+
+- `pipeline_step1_preprocess.py` — preprocess raw EDF files and cache intermediate results
+- `pipeline_step2_analyze.py` — perform staging, PSD calculations, and statistical summaries
+- `pipeline_step3_merge.py` — merge analyzed outputs and generate figures
+
+You can still orchestrate everything with `run_pipeline.py` and a JSON config.
 
 `pipeline.config.example.json` shows the expected keys:
 

--- a/pipeline_step1_preprocess.py
+++ b/pipeline_step1_preprocess.py
@@ -1,0 +1,1396 @@
+import sys
+import os
+
+# パスをsys.pathに追加
+sys.path.append("/p-antipsychotics-sleep/")
+
+import os
+import sys
+import argparse
+from pathlib import Path
+import pandas as pd
+import numpy as np
+import faster2lib.eeg_tools as et
+import re
+from datetime import datetime, timedelta
+from scipy import signal
+from hmmlearn import hmm, base
+from sklearn import mixture
+import matplotlib as mpl
+from matplotlib.figure import Figure
+from mpl_toolkits.mplot3d import axes3d
+from scipy import linalg, stats
+from scipy.spatial import distance
+from scipy.stats import multivariate_normal
+import pickle
+from glob import glob
+import mne
+import logging
+from logging import getLogger, StreamHandler, FileHandler, Formatter
+import traceback
+
+FASTER2_NAME = 'FASTER2 version 0.4.1'
+STAGE_LABELS = ['Wake', 'REM', 'NREM']
+XLABEL = 'Total low-freq. log-powers'
+YLABEL = 'Total high-freq. log-powers'
+ZLABEL = 'REM metric'
+SCATTER_PLOT_FIG_WIDTH = 6   # inch
+SCATTER_PLOT_FIG_HEIGHT = 6  # inch
+FIG_DPI = 100  # dot per inch
+COLOR_WAKE = '#DC267F'
+COLOR_NREM = '#648FFF'
+COLOR_REM = '#FFB000'
+COLOR_LIGHT = '#FFD700'  # 'gold'
+COLOR_DARK = '#696969'  # 'dimgray'
+COLOR_DARKLIGHT = 'lightgray'  # light hours in DD condition
+
+class CustomedGHMM(hmm.GaussianHMM):
+    def __init__(self, n_components=1, covariance_type='diag',
+                 min_covar=1e-3,
+                 startprob_prior=1.0, transmat_prior=1.0,
+                 means_prior=0, means_weight=0,
+                 covars_prior=1e-2, covars_weight=1,
+                 algorithm="viterbi", random_state=None,
+                 n_iter=10, tol=1e-2, verbose=False,
+                 params="stmc", init_params="stmc"):
+        super().__init__(n_components, covariance_type,
+                         min_covar, startprob_prior, transmat_prior,
+                         means_prior, means_weight,
+                         covars_prior, covars_weight,
+                         algorithm, random_state,
+                         n_iter, tol, verbose,
+                         params, init_params)
+        self.wr_boundary = None
+        self.nr_boundary = None
+        self.max_rem_ax = None
+
+    def set_wr_boundary(self, wr_boundary):
+        # Wake/REM boundary. REM cluster cannot grow below this boundary
+        self.wr_boundary = wr_boundary
+
+    def set_nr_boundary(self, nr_boundary):
+        # NREM/REM boundary. REM cluster cannot grow beyond this boundary
+        self.nr_boundary = nr_boundary
+
+    def set_max_rem_ax(self, max_rem_ax_len):
+        # maximum length of REM's principal axis
+        self.max_rem_ax = max_rem_ax_len
+
+    def _confine_REM_in_boundary(self, rem_mean, rem_cov):
+        """ By definition, REM cluster is not likely z (i.e. REM-metric)<REM_floor and
+        x (i.e. low-freq power)>0.
+        This function focuses on the ellipsoid that represents the 95% confidence area
+        of REM cluster. If this function finds any principal axis of the ellipsoid
+        penetrating the REM floor or the NREM wall (i.e. the end-point of the principal
+        axis at z<REM_floor or x>0), it shrinks the length of the axis to the point on
+        the constraints.
+        """
+
+        w, v = linalg.eigh(rem_cov)
+        # all eigenvalues must be positive
+        if np.any(w <= 0):
+            raise ValueError('Invalid_REM_Cluster')
+
+        w = 2 * np.sqrt(w)  # 95% confidence (2SD) area
+
+        # confine above REM floor
+        prn_ax = v@np.diag(w)  # 3x3 matrix: each column is the principal axis
+        for i in range(3):
+            arr_hd = rem_mean + prn_ax[:, i]  # the arrow head from the mean
+            # the negative arrow head from the mean
+            narr_hd = rem_mean - prn_ax[:, i]
+            if arr_hd[2] < self.wr_boundary:
+                sr = (rem_mean[2] - self.wr_boundary) / \
+                    (rem_mean[2] - arr_hd[2])  # shrink ratio
+            elif narr_hd[2] < self.wr_boundary:
+                sr = (rem_mean[2] - self.wr_boundary)/(rem_mean[2] - narr_hd[2])
+            else:
+                sr = 1
+            w[i] = w[i] * sr
+        
+        # confine the REM cluster within negative low-freq and above the diagonal line
+        prn_ax = v@np.diag(w)  # 3x3 matrix: each column is the principal axis
+        for i in range(3):
+            arr_hd = rem_mean + prn_ax[:, i] # the arrow head from the mean
+            narr_hd = rem_mean - prn_ax[:, i] # the negative arrow head from the mean
+            
+            # condition 1: negative low-freq and BELOW the diagonal line
+            if arr_hd[0] > self.nr_boundary and arr_hd[1] < arr_hd[0]:
+                # condition 2: if positive high-freq > 0 then allow to grow onto the diagonal line
+                if arr_hd[1] > 0:
+                    sr = self._shrink_ratio(arr_hd, rem_mean)
+                # Otherwise (negative high-freq) then only allow to reach onto the y-axis. 
+                else: 
+                    sr = (self.nr_boundary - rem_mean[0])/(arr_hd[0] - rem_mean[0]) # shrink ratio
+            elif narr_hd[0] > self.nr_boundary and narr_hd[1] < narr_hd[0]:
+                if narr_hd[1] > 0:
+                    sr = self._shrink_ratio(narr_hd, rem_mean)
+                else: 
+                    sr = (self.nr_boundary - rem_mean[0])/(narr_hd[0] - rem_mean[0]) # shrink ratio
+            else:
+                sr = 1
+            w[i] = w[i] * sr
+
+        # confine the length of principal axes
+        prn_ax = v@np.diag(w/2)  # half w because it was doubled in the previous process
+        prn_ax_len = np.sqrt(np.diag(prn_ax.T@prn_ax)) # lengths of principal axes
+        for i in range(3):
+            if prn_ax_len[i] > self.max_rem_ax:
+                sr = self.max_rem_ax / prn_ax_len[i]
+            else:
+                sr = 1
+            w[i] = w[i] * sr
+        
+        cov_updated = v@np.diag((w/2)**2)@v.T
+
+        return cov_updated
+
+
+    def _confine_Wake_in_boundary(self, wake_mean, wake_cov):
+        """ By definition, Wake cluster is not likely to cross the diagonal line.
+        This function focuses on the ellipsoid that represents the 95% confidence area
+        of Wake cluster. If this function finds any principal axis of the ellipsoid
+        penetrating the diagonal line (i.e. the end-point of the principal
+        axis is in the area y < x), it shrinks the length of the axis to the point on
+        the constraints.
+        """
+
+        w, v = linalg.eigh(wake_cov)
+        # all eigenvalues must be positive
+        if np.any(w <= 0):
+            raise ValueError('Invalid_Wake_Cluster')
+
+        w = 2 * np.sqrt(w)  # 95% confidence (2SD) area
+        prn_ax = v@np.diag(w)  # 3x3 matrix: each column is the principal axis
+        # confine above diagonal line
+        for i in range(3):
+            arr_hd = wake_mean + prn_ax[:, i]  # the arrow head from the mean
+            # the negative arrow head from the mean
+            narr_hd = wake_mean - prn_ax[:, i]
+            if arr_hd[1] < arr_hd[0]:
+                sr = self._shrink_ratio(arr_hd, wake_mean)
+            elif narr_hd[1] < narr_hd[0]:
+                sr = self._shrink_ratio(narr_hd, wake_mean)
+            else:
+                sr = 1
+            w[i] = w[i] * sr
+
+
+        cov_updated = v@np.diag((w/2)**2)@v.T
+
+        return cov_updated
+
+    
+    def _confine_NREM_in_boundary(self, nrem_mean, nrem_cov):
+        """ By definition, NREM cluster is not likely to cross the diagonal line.
+        This function focuses on the ellipsoid that represents the 95% confidence area
+        of NREM cluster. If this function finds any principal axis of the ellipsoid
+        penetrating the diagonal line (i.e. the end-point of the principal
+        axis is in the area y > x), it shrinks the length of the axis to the point on
+        the constraints.
+        """
+
+        w, v = linalg.eigh(nrem_cov)
+        # all eigenvalues must be positive
+        if np.any(w <= 0):
+            raise ValueError('Invalid_NREM_Cluster')
+
+        w = 2 * np.sqrt(w)  # 95% confidence (2SD) area
+        prn_ax = v@np.diag(w)  # 3x3 matrix: each column is the principal axis
+
+        # confine above diagonal line
+        for i in range(3):
+            arr_hd = nrem_mean + prn_ax[:, i]  # the arrow head from the mean
+            # the negative arrow head from the mean
+            narr_hd = nrem_mean - prn_ax[:, i]
+            if arr_hd[1] > arr_hd[0]:
+                sr = self._shrink_ratio(arr_hd, nrem_mean)
+            elif narr_hd[1] > narr_hd[0]:
+                sr = self._shrink_ratio(narr_hd, nrem_mean)
+            else:
+                sr = 1
+            w[i] = w[i] * sr
+
+
+        cov_updated = v@np.diag((w/2)**2)@v.T
+
+        return cov_updated
+ 
+
+    def _shrink_ratio(self, arr_hd, mn):
+        r = (arr_hd[1] - mn[1])/(arr_hd[0]-mn[0])
+        x_on_diag = (mn[1] - r*mn[0])/(1-r)
+        sr = (x_on_diag - mn[0])/(arr_hd[0] - mn[0])
+        return sr
+
+
+    #pylint: disable = redefined-outer-name
+    def _do_mstep(self, stats):
+        # pylint: disable = attribute-defined-outside-init
+        ghmm_stats = stats
+        # pylint: disable = protected-access
+        base._BaseHMM._do_mstep(self, ghmm_stats)
+        means_prior = self.means_prior
+        means_weight = self.means_weight
+
+        denom = ghmm_stats['post'][:, np.newaxis]
+        if 'm' in self.params:
+            self.means_ = ((means_weight * means_prior + ghmm_stats['obs'])
+                           / (means_weight + denom))
+ 
+        if 'c' in self.params:
+            covars_prior = self.covars_prior
+            covars_weight = self.covars_weight
+            meandiff = self.means_ - means_prior
+
+            if self.covariance_type in ('spherical', 'diag'):
+                cv_num = (means_weight * meandiff**2
+                          + ghmm_stats['obs**2']
+                          - 2 * self.means_ * ghmm_stats['obs']
+                          + self.means_**2 * denom)
+                cv_den = max(covars_weight - 1, 0) + denom
+                self._covars_ = \
+                    (covars_prior + cv_num) / np.maximum(cv_den, 1e-5)
+                if self.covariance_type == 'spherical':
+                    self._covars_ = np.tile(
+                        self._covars_.mean(1)[:, np.newaxis],
+                        (1, self._covars_.shape[1]))
+            elif self.covariance_type in ('tied', 'full'):
+                cv_num = np.empty((self.n_components, self.n_features,
+                                   self.n_features))
+                for c in range(self.n_components):
+                    obsmean = np.outer(ghmm_stats['obs'][c], self.means_[c])
+
+                    cv_num[c] = (means_weight * np.outer(meandiff[c],
+                                                         meandiff[c])
+                                 + ghmm_stats['obs*obs.T'][c]
+                                 - obsmean - obsmean.T
+                                 + np.outer(self.means_[c], self.means_[c])
+                                 * ghmm_stats['post'][c])
+                cvweight = max(covars_weight - self.n_features, 0)
+                if self.covariance_type == 'tied':
+                    self._covars_ = ((covars_prior + cv_num.sum(axis=0)) /
+                                     (cvweight + ghmm_stats['post'].sum()))
+                elif self.covariance_type == 'full':
+                    #covars = ((covars_prior + cv_num) /
+                    #          (cvweight + ghmm_stats['post'][:, None, None]))
+                    covars = ((covars_prior + cv_num) /
+                            np.maximum(cvweight + ghmm_stats['post'][:, None, None], 1e-6))
+                    covars = np.nan_to_num(covars, nan=0.0, posinf=1e6, neginf=-1e6)
+                    confined_rem_cov = self._confine_REM_in_boundary(
+                        self.means_[1], covars[1])
+                    confined_wake_cov = self._confine_Wake_in_boundary(
+                        self.means_[0], covars[0])
+                    confined_nrem_cov = self._confine_NREM_in_boundary(
+                        self.means_[2], covars[2])
+                    self._covars_ = np.array(
+                        [confined_wake_cov, confined_rem_cov, confined_nrem_cov])
+
+
+def initialize_logger(log_file):
+    logger = getLogger(FASTER2_NAME)
+    logger.setLevel(logging.DEBUG)
+
+    file_handler = FileHandler(log_file)
+    stream_handler = StreamHandler()
+
+    file_handler.setLevel(logging.DEBUG)
+    stream_handler.setLevel(logging.NOTSET)
+    handler_formatter = Formatter('%(message)s')
+    file_handler.setFormatter(handler_formatter)
+    stream_handler.setFormatter(handler_formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+def print_log(msg):
+    if 'log' in globals():
+        log.debug(msg)
+    else:
+        print(msg)
+
+
+def print_log_exception(msg):
+    if 'log' in globals():
+        log.exception(msg)
+    else:
+        print(msg)
+
+
+def read_mouse_info(data_dir):
+    """This function reads the mouse.info.csv file
+    and returns a DataFrame with fixed column names.
+
+    Args:
+        data_dir (str): A path to the data directory that contains the mouse.info.csv
+
+
+        The data directory should include two information files:
+        1. exp.info.csv,
+        2. mouse.info.csv,
+        and one directory named "raw" that contains all EEG/EMG data to be processed
+
+    Returns:
+        DataFrame: A dataframe with a fixed column names
+    """
+
+    filepath = os.path.join(data_dir, "mouse.info.csv")
+
+    try:
+        codename = et.encode_lookup(filepath)
+    except LookupError as e:
+        print_log(e)
+        exit(1)
+
+    csv_df = pd.read_csv(filepath,
+                         engine="python",
+                         dtype={'Device label': str, 'Mouse group': str,
+                                'Mouse ID': str, 'DOB': str, 'Stats report': str, 'Note': str},
+                         names=["Device label", "Mouse group",
+                                "Mouse ID", "DOB", "Stats report", "Note"],
+                         skiprows=1,
+                         header=None,
+                         skipinitialspace=True,
+                         encoding=codename)
+
+    return csv_df
+
+
+# def read_exp_info(data_dir):
+#     """This function reads the exp.info.csv file
+#     and returns a DataFrame with fixed column names.
+
+#     Args:
+#         data_dir (str): A path to the data directory that contains the exp.info.csv
+
+#     Returns:
+#         DataFrame: A DataFrame with a fixed column names
+#     """
+
+#     filepath = os.path.join(data_dir, "exp.info.csv")
+
+#     csv_df = pd.read_csv(filepath,
+#                          engine="python",
+#                          names=["Experiment label", "Rack label",
+#                                 "Start datetime", "End datetime", "Sampling freq"],
+#                          skiprows=1,
+#                          header=None)
+
+#     return csv_df
+
+
+# def find_edf_files(data_dir):
+#     """returns list of edf files in the directory
+
+#     Args:
+#         data_dir (str): A path to the data directory
+
+#     Returns:
+#         [list]: A list returned by glob()
+#     """
+#     return glob(os.path.join(data_dir, '*.edf'))
+
+
+def read_voltage_matrices(data_dir, device_id, sample_freq, epoch_len_sec, epoch_num,
+                          start_datetime=None):
+    """ This function reads data files of EEG and EMG, then returns matrices
+    in the shape of (epochs, signals).
+
+    Args:
+        data_dir (str): a path to the dirctory that contains either dsi.txt/, pkl/ directory,
+        or an EDF file.
+        device_id (str): a transmitter ID (e.g., ID47476) or channel ID (e.g., 09).
+        sample_freq (int): sampling frequency
+        epoch_len_sec (int): the length of an epoch in seconds
+        epoch_num (int): the number of epochs to be read.
+        start_datetime (datetime): start datetime of the analysis (used only for EDF file and
+        dsi.txt).
+
+    Returns:
+        (np.array(2), np.arrray(2), bool): a pair of voltage 2D matrices in a tuple
+        and a switch to tell if there was pickled data.
+
+    Note:
+        This function looks into the data_dir/ and first try to read pkl files. If pkl files
+        are not found, it tries to read an EDF file. If the EDF file is also not found, it
+        tries to read dsi.txt files.
+    """
+
+    if os.path.exists(os.path.join(data_dir, 'pkl', f'{device_id}_EEG.pkl')):
+        # if it exists, read the pkl file
+        not_yet_pickled = False
+        # Try to read pickled data
+        pkl_path = os.path.join(data_dir, 'pkl', f'{device_id}_EEG.pkl')
+        with open(pkl_path, 'rb') as pkl:
+            print_log(f'Reading {pkl_path}')
+            eeg_vm = pickle.load(pkl)
+
+        pkl_path = os.path.join(data_dir, 'pkl', f'{device_id}_EMG.pkl')
+        with open(pkl_path, 'rb') as pkl:
+            print_log(f'Reading {pkl_path}')
+            emg_vm = pickle.load(pkl)
+
+    elif len(find_edf_files(data_dir)) > 0:
+        # try to read EDF file
+        not_yet_pickled = True
+        # read EDF file
+        edf_file = find_edf_files(data_dir)
+        if len(edf_file) != 1:
+            raise FileNotFoundError(
+                f'Too many EDF files were found:{edf_file}. '
+                'FASTER2 assumes there is only one file.')
+        edf_file = edf_file[0]
+
+        raw = mne.io.read_raw_edf(edf_file)
+        measurement_start_datetime = datetime.utcfromtimestamp(
+            raw.info['meas_date'][0]) + timedelta(microseconds=raw.info['meas_date'][1])
+        try:
+            if isinstance(start_datetime, datetime) and (measurement_start_datetime < start_datetime):
+                start_offset_sec = (
+                    start_datetime - measurement_start_datetime).total_seconds()
+                end_offset_sec = start_offset_sec + epoch_num * epoch_len_sec
+                bidx = (raw.times >= start_offset_sec) & (
+                    raw.times < end_offset_sec)
+                start_slice = np.where(bidx)[0][0]
+                end_slice = np.where(bidx)[0][-1]+1
+                eeg = raw.get_data(f'EEG{device_id}',
+                                   start_slice, end_slice)[0]
+                emg = raw.get_data(f'EMG{device_id}',
+                                   start_slice, end_slice)[0]
+            else:
+                eeg = raw.get_data(f'EEG{device_id}')[0]
+                emg = raw.get_data(f'EMG{device_id}')[0]
+        except ValueError:
+            print_log(f'Failed to extract the data of "{device_id}" from {edf_file}. '
+                      f'Check the channel name: "EEG/EMG{device_id}" is in the EDF file.')
+            raise
+        raw.close()
+        try:
+            eeg_vm = eeg.reshape(-1, epoch_len_sec * sample_freq)
+            emg_vm = emg.reshape(-1, epoch_len_sec * sample_freq)
+        except ValueError:
+            print_log(f'Failed to extract {epoch_num} epochs from {edf_file}. '
+                      'Check the validity of the epoch number, start datetime, '
+                      'and sampling frequency.')
+            raise
+    elif os.path.exists(os.path.join(data_dir, 'dsi.txt')):
+        # try to read dsi.txt
+        not_yet_pickled = True
+        try:
+            dsi_reader_eeg = et.DSI_TXT_Reader(os.path.join(data_dir, 'dsi.txt/'),
+                                               f'{device_id}', 'EEG',
+                                               sample_freq=sample_freq)
+            dsi_reader_emg = et.DSI_TXT_Reader(os.path.join(data_dir, 'dsi.txt/'),
+                                               f'{device_id}', 'EMG',
+                                               sample_freq=sample_freq)
+            if isinstance(start_datetime, datetime):
+                end_datetime = start_datetime + \
+                    timedelta(seconds=epoch_len_sec*epoch_num)
+                eeg_df = dsi_reader_eeg.read_epochs_by_datetime(
+                    start_datetime, end_datetime)
+                emg_df = dsi_reader_emg.read_epochs_by_datetime(
+                    start_datetime, end_datetime)
+            else:
+                eeg_df = dsi_reader_eeg.read_epochs(1, epoch_num)
+                emg_df = dsi_reader_emg.read_epochs(1, epoch_num)
+            eeg_vm = eeg_df.value.values.reshape(-1,
+                                                 epoch_len_sec * sample_freq)
+            emg_vm = emg_df.value.values.reshape(-1,
+                                                 epoch_len_sec * sample_freq)
+        except FileNotFoundError:
+            print_log(
+                f'The dsi.txt file for {device_id} was not found in {data_dir}.')
+            raise
+    else:
+        raise FileNotFoundError(
+            f'Data file was not found for device {device_id} in {data_dir}.')
+
+    expected_shape = (epoch_num, sample_freq * epoch_len_sec)
+    if (eeg_vm.shape != expected_shape) or (emg_vm.shape != expected_shape):
+        raise ValueError(f'Unexpected shape of matrices EEG:{eeg_vm.shape} or EMG:{emg_vm.shape}. '
+                         f'Expected shape is {expected_shape}. Check the validity of '
+                         'the data files or configurations '
+                         'such as the epoch number and the sampling frequency.')
+
+    return (eeg_vm, emg_vm, not_yet_pickled)
+
+
+# def interpret_datetimestr(datetime_str):
+#     """ Find a datetime string and convert it to a datatime object
+#     allowing some variant forms
+
+#     Args:
+#         datetime_str (string): a string containing datetime
+
+#     Returns:
+#         a datetime object
+
+#     Raises:
+#         ValueError: raised when interpretation is failed
+#     """
+
+#     datestr_patterns = [r'(\d{4})(\d{2})(\d{2})',
+#                         r'(\d{4})/(\d{1,2})/(\d{1,2})',
+#                         r'(\d{4})-(\d{1,2})-(\d{1,2})']
+
+#     timestr_patterns = [r'(\d{2})(\d{2})(\d{2})',
+#                         r'(\d{1,2}):(\d{1,2}):(\d{1,2})',
+#                         r'(\d{1,2})-(\d{1,2})-(\d{1,2})']
+
+#     datetime_obj = None
+#     for pat in datestr_patterns:
+#         matched = re.search(pat, datetime_str)
+#         if matched:
+#             year = int(matched.group(1))
+#             month = int(matched.group(2))
+#             day = int(matched.group(3))
+#             datetime_str = re.sub(pat, '', datetime_str)
+
+#             for pat_time in timestr_patterns:
+#                 matched_time = re.search(pat_time, datetime_str)
+#                 if matched_time:
+#                     hour = int(matched_time.group(1))
+#                     minuite = int(matched_time.group(2))
+#                     second = int(matched_time.group(3))
+#                     datetime_obj = datetime(year, month, day,
+#                                             hour, minuite, second)
+#                     break
+#             if not matched_time:
+#                 datetime_obj = datetime(year, month, day)
+#     if not datetime_obj:
+#         raise ValueError(
+#             'failed to interpret datetime string \'{}\''.format(datetime_str))
+
+#     return datetime_obj
+
+
+# def interpret_exp_info(exp_info_df, epoch_len_sec):
+#     try:
+#         start_datetime_str = exp_info_df['Start datetime'].values[0]
+#         end_datetime_str = exp_info_df['End datetime'].values[0]
+#         sample_freq = exp_info_df['Sampling freq'].values[0]
+#         exp_label = exp_info_df['Experiment label'].values[0]
+#         rack_label = exp_info_df['Rack label'].values[0]
+#     except KeyError as e:
+#         print_log(
+#             f'Failed to parse the column: {e} in exp.info.csv. Check the headers.')
+#         exit(1)
+
+#     start_datetime = interpret_datetimestr(start_datetime_str)
+#     end_datetime = interpret_datetimestr(end_datetime_str)
+
+#     epoch_num = int(
+#         (end_datetime - start_datetime).total_seconds() / epoch_len_sec)
+
+#     return (epoch_num, sample_freq, exp_label, rack_label, start_datetime, end_datetime)
+
+
+def psd(y, n_fft, sample_freq):
+    return signal.welch(y, nfft=n_fft, fs=sample_freq)[1][0:129]
+
+
+def plot_hist_on_separation_axis(path2figures, d, means, covars, weights, draw_pdf_plot=False):
+
+    if means[0] > means[1]:
+        # reverse the order
+        means = means[::-1]
+        covars = covars[::-1]
+        weights = weights[::-1]
+
+    d_axis = np.arange(-20, 20)
+
+    fig = Figure(figsize=(SCATTER_PLOT_FIG_WIDTH,
+                          SCATTER_PLOT_FIG_HEIGHT), dpi=FIG_DPI, facecolor='w')
+    ax = fig.add_subplot(111)
+    ax.set_xlim(-20, 20)
+    ax.set_ylim(0, 0.1)
+
+    ax.hist(d, bins=100, density=True)
+    ax.plot(d_axis, weights[0]*stats.norm.pdf(d_axis,
+                                              means[0], np.sqrt(covars[0])).ravel(), c=COLOR_WAKE)
+    ax.plot(d_axis, weights[1]*stats.norm.pdf(d_axis,
+                                              means[1], np.sqrt(covars[1])).ravel(), c=COLOR_NREM)
+    ax.axvline(x=means[0], color='black', dashes=[2, 2])
+    ax.axvline(x=means[1], color='black', dashes=[2, 2])
+    ax.axvline(x=np.mean(means), color='black')
+
+    ax.set_xlabel('', fontsize=10)
+    ax.set_ylabel('', fontsize=10)
+
+    _savefig(path2figures, 'histogram_on_separation_axis', fig, draw_pdf_plot)
+
+    return fig
+
+
+def plot_scatter2D(points_2D, classes, means, covariances, colors, xlabel, ylabel, diag_line=False):
+    fig = Figure(figsize=(SCATTER_PLOT_FIG_WIDTH,
+                          SCATTER_PLOT_FIG_HEIGHT), dpi=FIG_DPI, facecolor='w')
+    ax = fig.add_subplot(111)
+    ax.set_xlim(-20, 20)
+    ax.set_ylim(-20, 20)
+
+    for i, color in enumerate(colors):
+
+        ax.scatter(points_2D[classes == i, 0],
+                   points_2D[classes == i, 1], .01, color=color)
+
+        # Plot an ellipse to show the Gaussian component
+        if (len(means) > i and len(covariances) > i):
+            mean = means[i]
+            covar = covariances[i]
+            w, v = linalg.eigh(covar)
+            w = 4. * np.sqrt(w)  # 95% confidence (2SD) area (2*radius)
+            angle = np.arctan(v[1, 0] / v[0, 0])
+            angle = 180. * angle / np.pi  # convert to degrees
+            #ell = mpl.patches.Ellipse(
+            #    mean, w[0], w[1], 180. + angle, facecolor='none', edgecolor=color)
+            ell = mpl.patches.Ellipse(
+                xy=mean, width=w[0], height=w[1], angle=180. + angle, facecolor='none', edgecolor=color)
+            ax.add_patch(ell)
+    if diag_line == True:
+        ax.plot([-20, 20], [-20, 20], color='gray', linewidth=0.7)
+    ax.set_xlabel(xlabel, fontsize=10)
+    ax.set_ylabel(ylabel, fontsize=10)
+    return fig
+
+
+def pickle_voltage_matrices(eeg_vm, emg_vm, data_dir, device_id):
+    """ To save time for reading CSV files, pickle the voltage matrices
+    in pickle files.
+    
+    Args:
+        eeg_vm (np.array): voltage matrix for EEG data
+        emg_vm (np.array): voltage matrix for EMG data
+        data_dir (str):  path to the directory of pickled data (pkl/)
+        device_id (str): a string to identify the recording device (e.g. ID47467)
+"""
+    pickle_dir = os.path.join(data_dir, 'pkl/')
+    os.makedirs(pickle_dir, exist_ok=True)
+
+    # save EEG
+    pkl_path = os.path.join(pickle_dir, f'{device_id}_EEG.pkl')
+    if os.path.exists(pkl_path):
+        print_log(f'File already exists. Nothing to be done. {pkl_path}')
+    else:
+        with open(pkl_path, 'wb') as pkl:
+            print_log(f'Saving the voltage matrix into {pkl_path}')
+            pickle.dump(eeg_vm, pkl)
+
+    # save EMG
+    pkl_path = os.path.join(pickle_dir, f'{device_id}_EMG.pkl')
+    if os.path.exists(pkl_path):
+        print_log(f'File already exists. Nothing to be done. {pkl_path} ')
+    else:
+        with open(pkl_path, 'wb') as pkl:
+            print_log(f'Saving the voltage matrix into {pkl_path}')
+            pickle.dump(emg_vm, pkl)
+
+
+def pickle_powerspec_matrices(spec_norm_eeg, spec_norm_emg, result_dir_path, device_id):
+    """ pickles the power spectrum density matrices for subsequent analyses
+
+    Args:
+        spec_norm_eeg (dict): a dict returned by spectrum_normalize() for EEG data
+        spec_norm_emg (dict): a dict returned by spectrum_normalize() for EMG data
+        bidx_unknown (np.array): an array of the boolean index
+        result_dir_path (str):  path to the directory of the pickled data (PSD/)
+        device_id (str): a string to identify the recording device (e.g. ID47467)
+    """
+    pickle_dir = os.path.join(result_dir_path, 'PSD/')
+    os.makedirs(pickle_dir, exist_ok=True)
+
+    print_log(f'Saving PSD files')
+
+    # save EEG PSD
+    pkl_path = os.path.join(pickle_dir, f'{device_id}_EEG_PSD.pkl')
+    #if os.path.exists(pkl_path):
+    #    print_log(f'File already exists: {pkl_path}')
+    #else:
+    with open(pkl_path, 'wb') as pkl:
+        print_log(f'Saving the EEG PSD matrix into {pkl_path}')
+        pickle.dump(spec_norm_eeg, pkl)
+
+    # save EMG PSD
+    pkl_path = os.path.join(pickle_dir, f'{device_id}_EMG_PSD.pkl')
+    #if os.path.exists(pkl_path):
+    #    print_log(f'File already exists: {pkl_path} ')
+    #else:
+    with open(pkl_path, 'wb') as pkl:
+        print_log(f'Saving the EMG PSD matrix into {pkl_path}')
+        pickle.dump(spec_norm_emg, pkl)
+
+
+def pickle_cluster_params(means2, covars2, c_means, c_covars, result_dir_path, device_id):
+    """ pickles the cluster parameters
+    
+    Args:
+        means2 (np.array(2,2)): a mean matrix of 2 stage-clusters
+        covars2 (np.array(2,2,2)): a covariance matrix of 2 stage-clusters
+        c_means (np.array(3,3)):  a mean matrix of 3 stage-clusters
+        c_covars (np.array(3,3,3)): a covariance matrix of 3 stage-clusters
+    """
+    pickle_dir = os.path.join(result_dir_path, 'cluster_params/')
+    os.makedirs(pickle_dir, exist_ok=True)
+
+    # save
+    pkl_path = os.path.join(pickle_dir, f'{device_id}_cluster_params.pkl')
+    print_log(f'Saving the cluster parameters into {pkl_path}')
+    with open(pkl_path, 'wb') as pkl:
+        pickle.dump({'2stage-means': means2, '2stage-covars': covars2,
+                     '3stage-means': c_means, '3stage-covars': c_covars}, pkl)
+
+def remove_extreme_voltage(y, sample_freq):
+    """An optional function to remove periodic-spike noises such as
+    heart beat in EMG. Since the spikes are ofhen above 1.64 SD (upper 10%) 
+    within the data region of interest, FASTER2 tries to replace those points with
+    randam values.
+    Note: This function is destructive i.e. it changes values of the
+    given vector.
+
+
+    Args:
+        y (np.array(1)): a vector of voltages in an epoch
+        sample_freq (int): the sampling frequency
+    """
+    vm = y.reshape(-1, sample_freq*2) # 2 sec
+    for v in vm:
+        m = np.mean(v)
+        s = np.std(v)
+        bidx = (abs(v) - m) > 1.64*s
+        v[bidx] =  np.random.normal(m, s, np.sum(bidx))
+
+
+def remove_extreme_power(y):
+    """In FASTER2, the spectrum powers are normalized so that the mean and 
+    SD of each frequency power over all epochs become 0 and 1, respectively.  
+    This function removes extremely high or low powers in the normalized 
+    spectrum by replacing the value with a random number sampled from the 
+    noraml distribution: N(0, 1). 
+    
+    Args:
+        y (np.array(1)): a vector of normalized power spectrum
+    
+    Returns:
+        float: The ratio of the replaced exreme values in the given vector.
+    """
+    n_len = len(y)
+
+    bidx = (np.abs(y) > 3)  # extreme means over 3SD
+    n_extr = np.sum(bidx)
+
+    y[bidx] = np.random.normal(0, 1, n_extr)
+
+    return n_extr / n_len
+
+
+def spectrum_normalize(voltage_matrix, n_fft, sample_freq):
+    # power-spectrum normalization of EEG
+    psd_mat = np.apply_along_axis(lambda y: psd(
+        y, n_fft, sample_freq), 1, voltage_matrix)
+    psd_mat = 10*np.log10(psd_mat)  # decibel-like
+    psd_mean = np.apply_along_axis(np.nanmean, 0, psd_mat)
+    psd_sd = np.apply_along_axis(np.nanstd, 0, psd_mat)
+    spec_norm_fac = 1/psd_sd
+    psd_norm_mat = np.apply_along_axis(lambda y: spec_norm_fac*(y - psd_mean),
+                                       1,
+                                       psd_mat)
+    return {'psd': psd_norm_mat, 'mean': psd_mean, 'norm_fac': spec_norm_fac}
+
+
+def cancel_weight_bias(stage_coord_2D):
+    # Estimate the center of the two clusters
+    print_log('Estimate the bias of the two cluster means')
+    d = stage_coord_2D@np.array([1, -1]).T  # project onto the separation axis
+    d = d.reshape(-1, 1)
+    # Two states: active and quiet
+    gmm = mixture.BayesianGaussianMixture(n_components=2, n_init=10)
+    gmm.fit(d)
+    weights = gmm.weights_
+    means = gmm.means_.flatten()
+    covars = gmm.covariances_.flatten()
+
+    # this is supposed to be zero if weights are completely balanced
+    bias = np.mean(means[0:2])
+    s = bias/np.sqrt(2)  # x,y-axis components
+    print_log(f'Estimated bias: {s}')
+
+    stage_coord_2D = stage_coord_2D + [-s, s]
+
+    return {'proj_data': d, 'means': means, 'covars': covars, 'weights': weights, 'stage_coord_2D': stage_coord_2D}
+
+
+def classify_active_and_NREM(stage_coord_2D):
+    # Initialize active/stative(NREM) clusters by Gaussian mixture model ignoring transition probablity
+    print_log('Initialize active/NREM clusters with the diagonal line')
+
+    # projection onto the separation "line" (which is perpendicular to the separation "axis")
+    stage_coord_1DD = stage_coord_2D@np.array([1, 1]).T
+    bidx_over_outliers = stage_coord_1DD > (
+        np.mean(stage_coord_1DD) + 3*np.std(stage_coord_1DD))
+    bidx_under_outliers = stage_coord_1DD < (
+        np.mean(stage_coord_1DD) - 3*np.std(stage_coord_1DD))
+    bidx_valid = ~(bidx_over_outliers | bidx_under_outliers)
+
+    # To estimate clusters, use only epochs projected within the reasonable region on the separation line (<3SD)
+    def _geo_classifier(coord):
+        # geometrical classifier (simpl separation by the diagonal line)
+        if coord[0] - coord[1] > 0:
+            return 1
+        else:
+            return 0
+
+    # Means and covariances of the active and NREM clusters
+    geo_pred = np.array([_geo_classifier(c) for c in stage_coord_2D])
+    mm_2D = np.array([
+        np.mean(stage_coord_2D[geo_pred == 0 & bidx_valid], axis=0),
+        np.mean(stage_coord_2D[geo_pred == 1 & bidx_valid], axis=0),
+    ])
+    cc_2D = np.array([
+        np.cov(stage_coord_2D[geo_pred == 0 & bidx_valid], rowvar=False),
+        np.cov(stage_coord_2D[geo_pred == 1 & bidx_valid], rowvar=False)
+    ])
+
+    likelihood = np.stack([multivariate_normal.pdf(stage_coord_2D, mean=mm_2D[i], cov=cc_2D[i])
+                           for i in [0, 1]])
+    geo_pred_proba = (likelihood / likelihood.sum(axis=0))
+
+    return (geo_pred, geo_pred_proba.T, mm_2D, cc_2D)
+
+
+def classify_active_and_NREM_by_GHMM(stage_coord_2D, pred_2D, mm_2D, cc_2D):
+    # Initialize active/stative(NREM) clusters by Gaussian mixture model ignoring transition probablity
+    print_log('Classify active/NREM clusters with GHMM')
+
+    weights = np.array(
+        [np.sum(pred_2D == 0), np.sum(pred_2D == 1)])/len(pred_2D)
+
+    ghmm_2D = hmm.GaussianHMM(
+        n_components=2, covariance_type='full', init_params='t', params='tmcs')
+    ghmm_2D.startprob_ = weights
+    ghmm_2D.means_ = mm_2D
+    ghmm_2D.covars_ = cc_2D
+
+    ghmm_2D.fit(stage_coord_2D)
+    ghmm_2D_pred = ghmm_2D.predict(stage_coord_2D)
+    ghmm_2D_proba = ghmm_2D.predict_proba(stage_coord_2D)
+    return (ghmm_2D_pred, ghmm_2D_proba, ghmm_2D.means_, ghmm_2D.covars_)
+
+
+def classify_Wake_and_REM(stage_coord_active, rem_floor):
+    # Classify REM and Wake in the active cluster in the 3D space  (Low freq. x High freq. x REM metric)
+    print_log('Classify REM and Wake clusters with GMM')
+
+    # exclude intermediate points between REM and Wake, and points having substantial sleep_freq power
+    bidx_wake_rem = ((stage_coord_active[:, 2] > rem_floor) | (
+        stage_coord_active[:, 2] < 0)) & (stage_coord_active[:, 0] < 0)
+    stage_coord_wake_rem = stage_coord_active[bidx_wake_rem, :]
+
+    # gmm for wake & REM
+    gmm_wr = mixture.GaussianMixture(n_components=3, n_init=100, means_init=[
+                                     [-5, 5, -10], [0, 0, 20], [0, 0, 0]])  # Wake, REM, intermediate
+    gmm_wr.fit(stage_coord_wake_rem)
+    ww_wr = gmm_wr.weights_
+    mm_wr = gmm_wr.means_
+    cc_wr = gmm_wr.covariances_
+    pred_wr = gmm_wr.predict(stage_coord_active)
+    pred_wr_proba = gmm_wr.predict_proba(stage_coord_active)
+
+    # Treat the intermediate as wake
+    pred_wr[pred_wr == 2] = 0
+    pred_wr_proba = np.array([[x[0]+x[2], x[1]] for x in pred_wr_proba])
+
+    # The subsequent process uses the Wake and REM clusters
+    ww_wr = ww_wr[np.r_[0, 1]]
+    mm_wr = mm_wr[np.r_[0, 1]]
+    cc_wr = cc_wr[np.r_[0, 1]]
+
+    if mm_wr[0, 2] > mm_wr[1, 2]:
+        # flip the order of clusters to assure the order of indices 0:Wake, 1:REM
+        mm_wr = np.array([mm_wr[1], mm_wr[0]])
+        cc_wr = np.array([cc_wr[1], cc_wr[0]])
+        pred_wr = np.array([0 if x == 1 else 1 for x in pred_wr])
+        pred_wr_proba = pred_wr_proba[:, np.r_[1, 0]]
+
+    return (pred_wr, pred_wr_proba, mm_wr, cc_wr, ww_wr)
+
+
+def classify_three_stages(stage_coord, mm_3D, cc_3D, weights_3c, max_rem_prn_len):
+    # pylint: disable = attribute-defined-outside-init
+    # classify REM, Wake, and NREM by Gaussian HMM in the 3D space
+    print_log('Classify REM, Wake, and NREM by Gaussian HMM')
+    ghmm_3D = CustomedGHMM(
+        n_components=3, covariance_type='full', init_params='t', params='ct')
+    ghmm_3D.startprob_ = weights_3c
+    ghmm_3D.means_ = mm_3D
+    ghmm_3D.covars_ = cc_3D
+    ghmm_3D.set_wr_boundary(0)
+    ghmm_3D.set_nr_boundary(0)
+    ghmm_3D.set_max_rem_ax(max_rem_prn_len)
+
+    ghmm_3D.fit(stage_coord)
+    pred_3D = ghmm_3D.predict(stage_coord)
+    pred_3D_proba = ghmm_3D.predict_proba(stage_coord)
+    pred_3D_mm = ghmm_3D.means_
+    pred_3D_cc = ghmm_3D.covars_
+
+    return (pred_3D, pred_3D_proba, pred_3D_mm, pred_3D_cc)
+
+
+def classify_two_stages(stage_coord, pred_2D_org, mm_2D_org, cc_2D_org, mm_active, cc_active):
+    ndata = len(stage_coord)
+    bidx_active = (pred_2D_org == 0)
+    # perform GMM to refine active/NREM classification
+    pred_2D, pred_2D_proba, mm_2D, cc_2D = classify_active_and_NREM_by_GHMM(
+        stage_coord[:, 0:2], pred_2D_org, mm_2D_org, cc_2D_org)
+
+    # construct 3D means and covariances from mm_2D and mm_active with TINY (non-effective) REM cluster
+    # This non-effective REM cluster is just for convenience of plotting, so has nothing to do with analytical process.
+    mm_3D = np.vstack([mm_active[0], [0, 0, 100], np.mean(
+        stage_coord[pred_2D == 1], axis=0)])  # Wake, REM, NREM
+    cc_3D = np.vstack([[cc_active[0]], [np.diag([0.01, 0.01, 0.01])], [
+                      np.cov(stage_coord[pred_2D == 1], rowvar=False)]])
+
+    # change label of NREM from 1 to 2 so that REM can use label:1
+    pred_3D = np.array([2 if x == 1 else 0 for x in pred_2D])
+    idx_active = np.where(bidx_active)[0]
+    # idx_REMlike = idx_active[bidx_REMlike]
+    # pred_3D[idx_REMlike] = 1
+
+    pred_3D_proba = np.zeros([ndata, 3])
+    # probability of REM is always zero, but sometimes REM like.
+    pred_3D_proba[:, np.r_[0, 2]] = pred_2D_proba
+
+    return pred_2D, pred_2D_proba, mm_2D, cc_2D, pred_3D, pred_3D_proba, mm_3D, cc_3D
+
+
+def classification_process(stage_coord, rem_floor):
+    if np.any(np.isnan(stage_coord)) or np.any(np.isinf(stage_coord)):
+        raise ValueError(f"Invalid values in stage_coord: {stage_coord}")
+    ndata = len(stage_coord)
+
+    # 2-stage classification
+    print("classify active and NREM")
+    # classify active and NREM clusters on the 2D plane of (Low freq. x High freq.)
+    pred_2D, pred_2D_proba, mm_2D, cc_2D = classify_active_and_NREM(
+        stage_coord[:, 0:2])
+
+    # Calculate the length of the longest principal axis of the active cluster
+    w, v = linalg.eigh(cc_2D[0])
+    w = np.sqrt(w)
+    prn_ax = v@np.diag(w) # each column is the principal axis
+    prn_ax_len = np.sqrt(np.diag(prn_ax.T@prn_ax))
+    max_prn_ax_len = np.max(prn_ax_len)
+
+    # Classify REM and Wake in the active cluster in the 3D space  (Low freq. x High freq. x REM metric)
+    bidx_active = (pred_2D == 0)
+    stage_coord_active = stage_coord[bidx_active, :]
+    # pylint: disable=unused-variable
+    print("classify Wake and REM")
+    pred_active, pred_active_proba, mm_active, cc_active, ww_active = classify_Wake_and_REM(
+        stage_coord_active, rem_floor)
+
+    # If the z values of the both clusters are negative or zero, it means there is no REM cluster
+    if np.all(mm_active[:, 2] <= 0):
+        # process for data NOT having effective REM cluster
+        print_log('No effective REM cluster was found.')
+
+        pred_2D, pred_2D_proba, mm_2D, cc_2D, pred_3D, pred_3D_proba, mm_3D, cc_3D = classify_two_stages(
+            stage_coord, pred_2D, mm_2D, cc_2D, mm_active, cc_active)
+
+    else:
+        # process for data having effective REM culster (this is the standard process)
+
+        # construct 3D means and covariances from mm_2D and mm_active
+        # Wake, REM, NREM
+        mm_3D = np.vstack(
+            [mm_active, np.mean(stage_coord[pred_2D == 1], axis=0)])
+        cc_3D = np.vstack(
+            [cc_active, [np.cov(stage_coord[pred_2D == 1], rowvar=False)]])
+
+        # three cluster weights; Wake, REM, NREM
+        weights_3c = np.array([np.sum(pred_active == 0), np.sum(
+            pred_active == 1), np.sum(pred_2D == 1)])/ndata
+
+        # 3-stage classification: classify REM, Wake, and NREM by Gaussian HMM on the 3D space
+        try:
+            pred_3D, pred_3D_proba, mm_3D, cc_3D = classify_three_stages(
+                stage_coord, mm_3D, cc_3D, weights_3c, max_prn_ax_len)
+        except ValueError as valerr:
+            if valerr.args[0] == 'Invalid_REM_Cluster':
+                print_log('REM cluster is invalid.')
+                pred_2D, pred_2D_proba, mm_2D, cc_2D, pred_3D, pred_3D_proba, mm_3D, cc_3D = classify_two_stages(
+                    stage_coord, pred_2D, mm_2D, cc_2D, mm_active, cc_active)
+            else:
+                raise
+
+    return pred_2D, pred_2D_proba, mm_2D, cc_2D, pred_3D, pred_3D_proba, mm_3D, cc_3D
+
+
+def draw_scatter_plots(path2figures, stage_coord, pred2, means2, covars2, c_pred3, c_means, c_covars, draw_pdf_plot=False):
+    print_log('Drawing scatter plots')
+
+    colors = [COLOR_WAKE, COLOR_NREM]
+    axes = [0, 1]
+    points = stage_coord[:, np.r_[axes]]
+    fig = plot_scatter2D(points, pred2, means2, covars2,
+                         colors, XLABEL, YLABEL, diag_line=True)
+    _savefig(path2figures, 'ScatterPlot2D_LowFreq-HighFreq_Axes_Active-NREM', fig, draw_pdf_plot)
+
+    points_active = stage_coord[((c_pred3 == 0) | (c_pred3 == 1)), :]
+    pred_active = c_pred3[((c_pred3 == 0) | (c_pred3 == 1))]
+
+    axes = [0, 2]  # Low-freq axis & REM axis
+    points_prj = stage_coord[:, np.r_[axes]]
+    colors = [COLOR_WAKE, COLOR_REM, COLOR_NREM]
+    mm = np.array([m[np.r_[axes]] for m in c_means[np.r_[0, 1, 2]]])
+    cc = np.array([c[np.r_[axes]][:, np.r_[axes]]
+                   for c in c_covars[np.r_[0, 1, 2]]])
+    fig = plot_scatter2D(points_prj, c_pred3, mm,
+                         cc, colors, XLABEL, ZLABEL)
+    _savefig(path2figures, 'ScatterPlot2D_LowFreq-REM_axes', fig, draw_pdf_plot)
+
+    axes = [1, 2]  # High-freq axis & REM axis
+    points_prj = stage_coord[:, np.r_[axes]]
+    mm = np.array([m[np.r_[axes]] for m in c_means[np.r_[0, 1, 2]]])
+    cc = np.array([c[np.r_[axes]][:, np.r_[axes]]
+                   for c in c_covars[np.r_[0, 1, 2]]])
+    fig = plot_scatter2D(points_prj, c_pred3, mm,
+                         cc, colors, YLABEL, ZLABEL)
+    _savefig(path2figures, 'ScatterPlot2D_HighFreq-REM_axes', fig, draw_pdf_plot)
+
+    axes = [0, 1]  # Low-freq axis & High-freq axis
+    points_prj = stage_coord[:, np.r_[axes]]
+    colors = [COLOR_WAKE, COLOR_REM, COLOR_NREM]
+    mm_proj = np.array([m[np.r_[axes]] for m in c_means[np.r_[0, 1, 2]]])
+    cc_proj = np.array([c[np.r_[axes]][:, np.r_[axes]]
+                        for c in c_covars[np.r_[0, 1, 2]]])
+    fig = plot_scatter2D(points_prj, c_pred3, mm_proj,
+                         cc_proj, colors, XLABEL, YLABEL, diag_line=True)
+    _savefig(path2figures, 'ScatterPlot2D_LowFreq-HighFreq_axes_Wake_REM_NREM', fig, draw_pdf_plot)
+
+    colors = [COLOR_WAKE, COLOR_REM, COLOR_NREM]
+    colors_light = [lighten_color(c) for c in colors]
+    fig = Figure(figsize=(SCATTER_PLOT_FIG_WIDTH,
+                          SCATTER_PLOT_FIG_HEIGHT), dpi=FIG_DPI, facecolor='w')
+    ax = fig.add_subplot(111, projection='3d')
+    ax.view_init(elev=10, azim=-135)
+
+    ax.set_xlim(-20, 20)
+    ax.set_ylim(-20, 20)
+    ax.set_zlim(-20, 20)
+    ax.set_xlabel(XLABEL, fontsize=10, rotation=0)
+    ax.set_ylabel(YLABEL, fontsize=10, rotation=0)
+    ax.set_zlabel(ZLABEL, fontsize=10, rotation=0)
+    ax.tick_params(axis='both', which='major', labelsize=8)
+
+    for c in set(c_pred3):
+        t_points = stage_coord[c_pred3 == c]
+        ax.scatter3D(t_points[:, 0], t_points[:, 1], min(
+            ax.get_zlim()), s=0.005, color=colors_light[c])
+        ax.scatter3D(t_points[:, 0], max(ax.get_ylim()),
+                     t_points[:, 2], s=0.005, color=colors_light[c])
+        ax.scatter3D(max(ax.get_xlim()),
+                     t_points[:, 1], t_points[:, 2], s=0.005, color=colors_light[c])
+
+        ax.scatter3D(t_points[:, 0], t_points[:, 1],
+                     t_points[:, 2], s=0.01, color=colors[c])
+
+    _savefig(path2figures, 'ScatterPlot3D', fig, draw_pdf_plot)
+
+
+def _savefig(output_dir, basefilename, fig, draw_pdf_plot):
+    # PNG
+    filename = f'{basefilename}.png'
+    fig.savefig(os.path.join(output_dir, filename), pad_inches=0,
+                bbox_inches='tight', dpi=100)
+    # PDF
+    if draw_pdf_plot:
+        filename = f'{basefilename}.pdf'
+        fig.savefig(os.path.join(output_dir, 'pdf', filename), pad_inches=0,
+                    bbox_inches='tight', dpi=100)
+
+def find_edf_files(data_dir):
+    """returns list of edf files in the directory
+
+    Args:
+        data_dir (str): A path to the data directory
+
+    Returns:
+        [list]: A list returned by glob()
+    """
+    return glob(os.path.join(data_dir, '*.edf'))
+
+def lighten_color(hex):
+    return rgb_to_hex(tuple([int(x+(255-x)*0.5) for x in hex_to_rgb(hex)]))
+
+
+def hex_to_rgb(hex_code):
+    h = hex_code.lstrip('#')
+    rgb = tuple(int(h[i:i+2], 16) for i in (0, 2, 4))
+    return rgb
+
+
+def rgb_to_hex(rgb_tuple):
+    return '#%02x%02x%02x' % rgb_tuple
+
+
+def voltage_normalize(v_mat):
+    v_array = v_mat.flatten()
+    v_array = v_array[~np.isnan(v_array)]
+    bidx_over = v_array > (np.mean(v_array)+3*np.std(v_array))
+    bidx_under = v_array < (np.mean(v_array)-3*np.std(v_array))
+    bidx_valid = ~(bidx_over | bidx_under)
+    v_mat_norm = (
+        v_mat - np.mean(v_array[bidx_valid]))/np.std(v_array[bidx_valid])
+
+    return v_mat_norm
+
+
+
+# assures frequency bins compatibe among different sampling frequencies
+epoch_len_sec = 8
+sample_freq = 128
+n_fft = int(256 * sample_freq/100)
+# same frequency bins given by signal.welch()
+freq_bins = 1/(n_fft/sample_freq)*np.arange(0, 129)
+bidx_sleep_freq = (freq_bins < 4) | ((freq_bins > 10) &
+                                     (freq_bins < 20))  # without theta, 37 bins
+bidx_active_freq = (freq_bins > 30)  # 52 bins
+bidx_theta_freq = (freq_bins >= 4) & (freq_bins < 10)  # 15 bins
+bidx_delta_freq = (freq_bins < 4)  # 11 bins
+bidx_muscle_freq = (freq_bins > 30)  # 52 bins
+
+n_active_freq = np.sum(bidx_active_freq)
+n_sleep_freq = np.sum(bidx_sleep_freq)
+n_theta_freq = np.sum(bidx_theta_freq)
+n_delta_freq = np.sum(bidx_delta_freq)
+n_muscle_freq = np.sum(bidx_muscle_freq)
+
+rem_floor = np.sum(np.sqrt([n_muscle_freq, n_theta_freq]))
+
+def preprocess_edf(idx,edf,epoch_num,sample_freq,epoch_len_sec,result_dir,device_id,data_dir,offset_in_msec=0):
+    raw = mne.io.read_raw_edf(edf)
+    measurement_start_datetime = raw.info['meas_date']
+    eegname = 'EEG_{0}'.format(idx)
+    emgname = 'EMG_{0}'.format(idx)
+    eeg = raw.get_data(eegname)
+    #print(eeg.shape)
+    emg = raw.get_data(emgname)
+    raw.close()
+    start_idx=int(offset_in_msec*sample_freq/1000)
+    actual_epoch_num=int((eeg.shape[1]-start_idx)/sample_freq/epoch_len_sec)
+    if epoch_num>actual_epoch_num:
+        epoch_num=actual_epoch_num
+    end_idx=start_idx+epoch_num*sample_freq*epoch_len_sec
+    eeg=eeg[:,start_idx:end_idx]
+    emg=emg[:,start_idx:end_idx]
+    eeg_vm = eeg.reshape(-1, epoch_len_sec * int(sample_freq))
+    emg_vm = emg.reshape(-1, epoch_len_sec * int(sample_freq))
+    os.makedirs(os.path.join(data_dir,"pkl"),exist_ok=True)
+    os.makedirs(os.path.join(result_dir,"pkl"),exist_ok=True)
+    eeg_pkl_path=os.path.join(result_dir,'pkl', f'{device_id}_EEG.pkl')
+    #eeg_pkl_path = os.path.join(data_dir, 'pkl', f'{device_id}_EEG.pkl')
+    emg_pkl_path=os.path.join(result_dir,'pkl', f'{device_id}_EMG.pkl')
+    #emg_pkl_path = os.path.join(data_dir, 'pkl', f'{device_id}_EEG.pkl')
+
+
+    eeg_vm_org = eeg_vm[:epoch_num,]
+    emg_vm_org = emg_vm[:epoch_num,]
+
+    with open(eeg_pkl_path, 'wb') as pkl:
+        pickle.dump(eeg_vm_org, pkl)
+    with open(emg_pkl_path, 'wb') as pkl:
+        pickle.dump(emg_vm_org, pkl)
+
+    print_log('Applying the optional filter on the EEG signal')
+    epoch_sd = np.apply_along_axis(np.nanstd, 1 ,eeg_vm_org)
+    med_sd = np.median(epoch_sd)
+    bidx_no_eeg_signal = (epoch_sd / med_sd) < 0.3 # A definition of "NO signal of EEG"
+    eeg_vm_org[bidx_no_eeg_signal, :] = np.nan
+    print_log(f'The number of epochs with no EEG signal: {np.sum(bidx_no_eeg_signal)}')
+
+    # recover nans in the data if possible
+    nan_ratio_eeg = np.apply_along_axis(et.patch_nan, 1, eeg_vm_org)
+    nan_ratio_emg = np.apply_along_axis(et.patch_nan, 1, emg_vm_org)
+
+    # exclude unrecoverable epochs as unknown
+    bidx_unknown = np.apply_along_axis(np.any, 1, np.isnan(
+        eeg_vm_org)) | np.apply_along_axis(np.any, 1, np.isnan(emg_vm_org))
+    eeg_vm = eeg_vm_org[~bidx_unknown, :]
+    emg_vm = emg_vm_org[~bidx_unknown, :]
+
+    # make data comparable among different mice. Not necessary for staging,
+    # but convenient for subsequnet analyses.
+    eeg_vm_norm = voltage_normalize(eeg_vm)
+    emg_vm_norm = voltage_normalize(emg_vm)
+
+    # remove extreme voltages (e.g. heart beat) from EMG
+    print_log('Applying the optional filter on the EMG signal')
+    np.apply_along_axis(remove_extreme_voltage, 1, emg_vm_norm, sample_freq)
+
+    # power-spectrum normalization of EEG and EMG
+    spec_norm_eeg = spectrum_normalize(eeg_vm_norm, n_fft, sample_freq)
+    spec_norm_emg = spectrum_normalize(emg_vm_norm, n_fft, sample_freq)
+    psd_norm_mat_eeg = spec_norm_eeg['psd']
+    psd_norm_mat_emg = spec_norm_emg['psd']
+
+    # remove extreme powers
+    extrp_ratio_eeg = np.apply_along_axis(
+        remove_extreme_power, 1, psd_norm_mat_eeg)
+    extrp_ratio_emg = np.apply_along_axis(
+        remove_extreme_power, 1, psd_norm_mat_emg)
+
+    # save the PSD matrices and associated factors for subsequent analyses
+    ## set bidx_unknown; other factors were set by spectrum_normalize()
+    spec_norm_eeg['bidx_unknown'] = bidx_unknown
+    spec_norm_emg['bidx_unknown'] = bidx_unknown
+    pickle_powerspec_matrices(
+        spec_norm_eeg, spec_norm_emg, result_dir, device_id)
+
+    # spread epochs on the 3D (Low freq. x High freq. x REM metric) space
+    psd_mat = np.concatenate([
+        psd_norm_mat_eeg.reshape(*psd_norm_mat_eeg.shape, 1),
+        psd_norm_mat_emg.reshape(*psd_norm_mat_emg.shape, 1)
+    ], axis=2)
+    stage_coord = np.array([(
+        np.sum(y[bidx_sleep_freq, 0])/np.sqrt(n_sleep_freq),
+        np.sum(y[bidx_active_freq, 0])/np.sqrt(n_active_freq),
+        np.sum(y[bidx_theta_freq, 0])/np.sqrt(n_theta_freq)-np.sum(y[bidx_delta_freq, 0]) /
+        np.sqrt(n_delta_freq) -
+        np.sum(y[bidx_muscle_freq, 1]) / np.sqrt(n_muscle_freq)
+    ) for y in psd_mat])
+    ndata = len(stage_coord)
+
+    # cancel the weight bias of active/NREM clusters
+    cwb = cancel_weight_bias(stage_coord[:, 0:2])
+    stage_coord[:, 0:2] = cwb['stage_coord_2D']
+
+    # run the classification process
+    pred_2D, pred_2D_proba, means_2D, covars_2D, pred_3D, pred_3D_proba, means_3D, covars_3D = classification_process(
+            stage_coord, rem_floor)
+
+
+    # output staging result
+    stage_proba = np.zeros(3*epoch_num).reshape(epoch_num, 3)
+    proba_REM = pred_3D_proba[:, 1]
+    proba_WAKE = pred_3D_proba[:, 0]
+    proba_NREM = pred_3D_proba[:, 2]
+    stage_proba[~bidx_unknown, 0] = proba_REM
+    stage_proba[~bidx_unknown, 1] = proba_WAKE
+    stage_proba[~bidx_unknown, 2] = proba_NREM
+
+    stage_call = np.repeat('Unknown', epoch_num)
+    stage_call[~bidx_unknown] = np.array(
+        [STAGE_LABELS[y] for y in pred_3D])
+
+    # Print a brief result
+    print_log(f'2-stage means:\n {means_2D}')
+    print_log(f'2-stage covars:\n {covars_2D}')
+    print_log('\n')
+    print_log(f'3-stage means:\n{means_3D}')
+    print_log(f'3-stage covars:\n{covars_3D}')
+
+    # Compose stage table
+    extreme_power_ratio = np.zeros(2*epoch_num).reshape(epoch_num, 2)
+    extreme_power_ratio[~bidx_unknown, 0] = extrp_ratio_eeg
+    extreme_power_ratio[~bidx_unknown, 1] = extrp_ratio_emg
+
+    stage_table = pd.DataFrame({'Stage': stage_call,
+                                'REM probability': stage_proba[:, 0],
+                                'NREM probability': stage_proba[:, 2],
+                                'Wake probability': stage_proba[:, 1],
+                                'NaN ratio EEG-TS': nan_ratio_eeg,
+                                'NaN ratio EMG-TS': nan_ratio_emg,
+                                'Outlier ratio EEG-TS': extreme_power_ratio[:, 0],
+                                'Outlier ratio EMG-TS': extreme_power_ratio[:, 1]})
+    stage_file_path = os.path.join(result_dir, f'{device_id}.faster2.stage.csv')
+
+    with open(stage_file_path, 'w', encoding='UTF-8') as f:
+        f.write(f'# Start: {measurement_start_datetime} \n')
+        f.write(f'# Epoch num: {epoch_num}  Epoch length: {epoch_len_sec} [s]\n')
+        f.write(f'# Sampling frequency: {sample_freq} [Hz]\n')
+        f.write(f'# Staged by {FASTER2_NAME}\n')
+    with open(stage_file_path, 'a') as f:
+        print(f)
+        print(type(f))
+        print(type(stage_table))
+        stage_table.to_csv(f, header=True, index=False)
+        #stage_table.to_csv(f, header=True, index=False, line_terminator='\n')
+
+    path2figures = os.path.join(result_dir, 'figure', f'{device_id}')
+    os.makedirs(path2figures, exist_ok=True)
+
+    # draw the bias histogram
+    plot_hist_on_separation_axis(path2figures, cwb['proj_data'], cwb['means'], cwb['covars'], cwb['weights']) 
+
+    # draw scatter plots
+    draw_scatter_plots(path2figures, stage_coord, pred_2D, means_2D, covars_2D, pred_3D, means_3D, covars_3D)
+
+    # pickle cluster parameters
+    pickle_cluster_params(means_2D, covars_2D, means_3D, covars_3D, result_dir, device_id)
+
+
+def preprocess_project(prj_dir: Path, result_dir_name: str, epoch_len_sec: int, sample_freq: int, overwrite: bool = False, offset_in_msec: int = 0) -> None:
+    """Run preprocessing for every EDF file found under a project directory.
+
+    The function looks for ``*.edf`` files under ``prj_dir`` (recursively). For each
+    recording directory containing EDFs, a result directory named ``result_dir_name``
+    is created next to the ``data`` directory. Existing outputs are skipped unless
+    ``overwrite`` is set.
+    """
+
+    edf_paths = sorted(Path(prj_dir).rglob("*.edf"))
+    data_dirs = sorted({p.parent for p in edf_paths})
+
+    for data_dir in data_dirs:
+        record_dir = data_dir.parent
+        result_dir = record_dir / result_dir_name
+        if result_dir.exists() and not overwrite:
+            print_log(f"Skip existing {result_dir} (use --overwrite to force re-run)")
+            continue
+
+        result_dir.mkdir(parents=True, exist_ok=True)
+        print_log(f"Processing data directory: {data_dir}")
+
+        for idx, edf_path in enumerate(sorted(data_dir.glob("*.edf")), start=1):
+            with mne.io.read_raw_edf(edf_path, preload=False) as raw:
+                epoch_num = int(raw.n_times // (sample_freq * epoch_len_sec))
+
+            preprocess_edf(
+                idx,
+                str(edf_path),
+                epoch_num,
+                sample_freq,
+                epoch_len_sec,
+                str(result_dir),
+                edf_path.stem,
+                str(data_dir),
+                offset_in_msec=offset_in_msec,
+            )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Preprocess EDF files for EEG/EMG analysis")
+    parser.add_argument("--prj-dir", type=Path, required=True, help="Root directory that contains recording folders")
+    parser.add_argument("--result-dir-name", default="result", help="Name of the output folder created per recording")
+    parser.add_argument("--epoch-len-sec", type=int, default=8, help="Epoch length in seconds")
+    parser.add_argument("--sample-freq", type=int, default=128, help="Sampling frequency of the EDF files")
+    parser.add_argument("--overwrite", action="store_true", help="Recreate outputs even if they already exist")
+    parser.add_argument("--offset-in-msec", type=int, default=0, help="Trim the first N milliseconds from each recording")
+
+    args = parser.parse_args()
+    preprocess_project(
+        args.prj_dir,
+        args.result_dir_name,
+        args.epoch_len_sec,
+        args.sample_freq,
+        overwrite=args.overwrite,
+        offset_in_msec=args.offset_in_msec,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline_step2_analyze.py
+++ b/pipeline_step2_analyze.py
@@ -1,0 +1,2514 @@
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+import pandas as pd
+import os
+import sys
+sys.path.append('/p-antipsychotics-sleep')
+import numpy as np
+import pickle
+import argparse
+import copy
+import glob
+
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+import textwrap
+import stage
+
+import faster2lib.eeg_tools as et
+import faster2lib.summary_psd as sp
+import faster2lib.summary_common as sc
+
+from datetime import datetime
+import logging
+from logging import getLogger, StreamHandler, FileHandler, Formatter
+
+import warnings
+from datetime import datetime
+
+
+FASTER2_NAME = 'FASTER2 version 0.4.1'
+STAGE_LABELS = ['Wake', 'REM', 'NREM']
+XLABEL = 'Total low-freq. log-powers'
+YLABEL = 'Total high-freq. log-powers'
+ZLABEL = 'REM metric'
+SCATTER_PLOT_FIG_WIDTH = 6   # inch
+SCATTER_PLOT_FIG_HEIGHT = 6  # inch
+FIG_DPI = 100  # dot per inch
+COLOR_WAKE = '#DC267F'
+COLOR_NREM = '#648FFF'
+COLOR_REM = '#FFB000'
+COLOR_LIGHT = '#FFD700'  # 'gold'
+COLOR_DARK = '#696969'  # 'dimgray'
+COLOR_DARKLIGHT = 'lightgray'  # light hours in DD condition
+
+def initialize_logger(log_file):
+    logger = getLogger()
+    logger.setLevel(logging.INFO)
+
+    file_handler = FileHandler(log_file)
+    stream_handler = StreamHandler()
+
+    file_handler.setLevel(logging.INFO)
+    stream_handler.setLevel(logging.INFO)
+    handler_formatter = Formatter('%(message)s')
+    file_handler.setFormatter(handler_formatter)
+    stream_handler.setFormatter(handler_formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+def print_log(msg):
+    if 'log' in globals():
+        log.info(msg)
+    else:
+        print(msg)
+
+
+def print_log_exception(msg):
+    if 'log' in globals():
+        log.exception(msg)
+    else:
+        print(msg)
+
+
+def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
+    """ collects multiple mouse info
+
+    Arguments:
+        faster_dir_list [str] -- a list of paths for FASTER directories
+
+    Returns:
+        {'mouse_info':pd.DataFrame, 'epoch_num':int, 'sample_freq':np.float} -- A dict of
+        dataframe of the concatenated mouse info, the sampling frequency,
+        and the number of epochs
+    """
+    mouse_info_df = pd.DataFrame()
+    epoch_num_stored = None
+    sample_freq_stored = None
+    for faster_dir in faster_dir_list:
+        data_dir = os.path.join(faster_dir, 'data')
+
+        exp_info_df = stage.read_exp_info(data_dir)
+        # not used variable: rack_label, start_datetime, end_datetime
+        # pylint: disable=unused-variable
+        (epoch_num, sample_freq, exp_label, rack_label, \
+            start_datetime, end_datetime) = stage.interpret_exp_info(exp_info_df, epoch_len_sec)
+        if (epoch_num_stored != None) and epoch_num != epoch_num_stored:
+            raise ValueError('epoch number must be equal among the all dataset')
+        else:
+            epoch_num_stored = epoch_num
+        if (sample_freq_stored != None) and sample_freq != sample_freq_stored:
+            raise ValueError('sample freq must be equal among the all dataset')
+        else:
+            sample_freq_stored = sample_freq
+
+        m_info = stage.read_mouse_info(data_dir)
+        m_info['Experiment label'] = exp_label
+        m_info['FASTER_DIR'] = faster_dir
+        mouse_info_df = pd.concat([mouse_info_df, m_info])
+    return ({'mouse_info': mouse_info_df, 'epoch_num': epoch_num, 'sample_freq': sample_freq, 'start_datetime': start_datetime})
+def stagetime_in_a_day(stage_call):
+    """Count each stage in the stage_call list and calculate
+    the daily stage time in minuites.
+    Notice this function assumes that the length of the
+    stage_call is multiple of days. Also it assumes that the
+    stage calls are CAPITALIZED.
+
+    Arguments:
+        stage_call {np.array} -- an array of stage calls (e.g. ['WAKE', 'NREM', ...])
+
+    Returns:
+        [tuple] -- A tuple of sleep times (rem, nrem, wake, unknown)
+    """
+    ndata = len(stage_call)
+
+    rem = 1440*np.sum(stage_call == "REM")/ndata
+    nrem = 1440*np.sum(stage_call == "NREM")/ndata
+    wake = 1440*np.sum(stage_call == "WAKE")/ndata
+    unknown = 1440*np.sum(stage_call == "UNKNOWN")/ndata
+
+    return (rem, nrem, wake, unknown)
+
+
+def stagetime_profile(stage_call, epoch_len_sec):
+    """ hourly profiles of stages over the recording
+
+    Arguments:
+        stage_call {np.array} -- an array of stage calls (e.g. ['WAKE',
+        'NREM', ...])
+
+    Returns:
+        [np.array(3, len(stage_calls))] -- each row corrensponds the
+        hourly profiles of stages over the recording (rem, nrem, wake)
+    """
+    print(stage_call.shape)
+    sm = stage_call.reshape(-1, int(3600/epoch_len_sec)
+                            )  # 60 min(3600 sec) bin
+    rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
+                    60 for s in sm])  # unit minuite
+    nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
+                     60 for s in sm])  # unit minuite
+    wake = np.array([np.sum(s == 'WAKE')*epoch_len_sec /
+                     60 for s in sm])  # unit minuite
+
+    return np.array([rem, nrem, wake])
+
+
+def stagetime_circadian_profile(stage_call, epoch_len_sec):
+    """hourly profiles of stages over a day (circadian profile)
+
+    Arguments:
+        stage_call {np.array} -- an array of stage calls (e.g. ['WAKE',
+        'NREM', ...])
+
+    Returns:
+        [np.array(2,3,24)] -- 1st axis: [mean, sd]
+                            x 2nd axis [rem, nrem, wake]
+                            x 3rd axis [24 hours]
+    """
+    # 60 min(3600 sec) bin
+    print(stage_call.shape)
+    sm = stage_call.reshape(-1, int(3600/epoch_len_sec))
+    rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
+                    60 for s in sm])  # unit minuite
+    nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
+                     60 for s in sm])  # unit minuite
+    wake = np.array([np.sum(s == 'WAKE')*epoch_len_sec /
+                     60 for s in sm])  # unit minuite
+
+    rem_mat = rem.reshape(-1, 24)
+    nrem_mat = nrem.reshape(-1, 24)
+    wake_mat = wake.reshape(-1, 24)
+
+    rem_mean = np.apply_along_axis(np.mean, 0, rem_mat)
+    rem_sd = np.apply_along_axis(np.std, 0, rem_mat)
+    nrem_mean = np.apply_along_axis(np.mean, 0, nrem_mat)
+    nrem_sd = np.apply_along_axis(np.std, 0, nrem_mat)
+    wake_mean = np.apply_along_axis(np.mean, 0, wake_mat)
+    wake_sd = np.apply_along_axis(np.std, 0, wake_mat)
+
+    return np.array([[rem_mean, nrem_mean, wake_mean], [rem_sd, nrem_sd, wake_sd]])
+
+
+def swtrans_circadian_profile(stage_call, epoch_len_sec):
+    """hourly sleep-wake transitions (Psw and Pws) over a day (circadian profile)
+
+    Arguments:
+        stage_call {np.array} -- an array of stage calls (e.g. ['WAKE',
+        'NREM', ...])
+
+    Returns:
+        [np.array(2,2,24)] -- 1st axis [mean, sd]
+                            x 2nd axis [Psw, Pws]
+                            x 3rd axis [24 hours]
+    """
+    # 60 min(3600 sec) bin
+    sw = swtrans_profile(stage_call, epoch_len_sec) # 1st axis [Psw, Pws] x 2nd axis [recordec hours e.g. 72 hours]
+
+    psw_mat = sw[0].reshape(-1, 24)
+    pws_mat = sw[1].reshape(-1, 24)
+
+    # "RuntimeWarning: Mean of empty slice" may occure here and safely ignorable
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        psw_mean = np.apply_along_axis(np.nanmean, 0, psw_mat)
+        psw_sd = np.apply_along_axis(np.nanstd, 0, psw_mat)
+        pws_mean = np.apply_along_axis(np.nanmean, 0, pws_mat)
+        pws_sd = np.apply_along_axis(np.nanstd, 0, pws_mat)
+
+    return np.array([[psw_mean, pws_mean], [psw_sd, pws_sd]])
+
+def hourly_bout_profile(bout_df, epoch_len_sec):
+    """hourly bout length and counts"""
+    seconds_per_hour = 3600
+    
+    # エポックを時間単位に変換
+    bout_df['start_time'] = (bout_df['start_idx'] * epoch_len_sec) / seconds_per_hour
+    bout_df['duration_sec'] = (bout_df['len'] * epoch_len_sec)     
+    # 時間を切り捨てて整数に変換
+    bout_df['hour'] = bout_df['start_time'].apply(lambda x: int(x))
+
+    # 各ステージの1時間毎のブート数と平均ブート長さを計算
+    bout_profile_df = bout_df.groupby(['hour', 'stage']).agg({'start_idx': 'count', 'duration_sec': 'mean'}).reset_index()
+    bout_profile_df.columns = ['hour', 'stage', 'bout_count', 'mean_duration_sec']
+    
+    # 全ての組み合わせのインデックスを作成
+    hours = bout_profile_df['hour'].unique()
+    stages = ['NREM', 'REM', 'WAKE']
+    all_combinations = pd.MultiIndex.from_product([hours, stages], names=['hour', 'stage'])
+    complete_df = pd.DataFrame(index=all_combinations).reset_index()
+
+    # 元のデータフレームと結合し、欠けている組み合わせを補完
+    bout_profile_df = pd.merge(complete_df, bout_profile_df, on=['hour', 'stage'], how='left')
+    bout_profile_df['bout_count'].fillna(0, inplace=True)
+    bout_profile_df['mean_duration_sec'].fillna(0, inplace=True)
+    
+    return bout_profile_df
+
+
+def transmat_from_stages(stages):
+    """transition probability matrix among each stage
+
+    Arguments:
+        stages {np.array} -- an array of stage calls (e.g. ['WAKE',
+        'NREM', ...])
+
+    Returns:
+        [np.array(3,3)] -- a 3x3 matrix of transition probabilites.
+        Notice the order is REM, WAKE, NREM.
+    """
+    rr = np.sum((stages[:-1] == 'REM') & (stages[1:] == 'REM'))  # REM -> REM
+    rw = np.sum((stages[:-1] == 'REM') & (stages[1:] == 'WAKE'))  # REM -> Wake
+    rn = np.sum((stages[:-1] == 'REM') & (stages[1:] == 'NREM'))  # REM -> NREM
+
+    wr = np.sum((stages[:-1] == 'WAKE') & (stages[1:] == 'REM'))  # Wake -> REM
+    ww = np.sum((stages[:-1] == 'WAKE') &
+                (stages[1:] == 'WAKE'))  # Wake-> Wake
+    wn = np.sum((stages[:-1] == 'WAKE') &
+                (stages[1:] == 'NREM'))  # Wake-> NREM
+
+    nr = np.sum((stages[:-1] == 'NREM') & (stages[1:] == 'REM'))  # NREM -> REM
+    nw = np.sum((stages[:-1] == 'NREM') &
+                (stages[1:] == 'WAKE'))  # NREM -> Wake
+    nn = np.sum((stages[:-1] == 'NREM') &
+                (stages[1:] == 'NREM'))  # NREM -> NREM
+
+    r_trans = rr + rw + rn
+    w_trans = wr + ww + wn
+    n_trans = nr + nw + nn
+    transmat = np.array(
+        [
+            [rr, rw, rn]/r_trans if r_trans > 0 else [np.nan]*3,
+            [wr, ww, wn]/w_trans if w_trans > 0 else [np.nan]*3,
+            [nr, nw, nn]/n_trans if n_trans > 0 else [np.nan]*3
+        ]
+    )
+
+    return transmat
+
+
+def swtrans_from_stages(stages):
+    """Sleep (REM+NREM) <> Wake transition probability matrix
+    among each stage
+
+    Arguments:
+        stages {np.array} -- an array of stage calls (e.g. ['WAKE',
+        'NREM', ...])
+
+    Returns:
+        [np.array(2)] -- a 1D array of transition probabilites.
+        Notice the order is Psw, Pws.
+    """
+    rr = np.sum((stages[:-1] == 'REM') & (stages[1:] == 'REM'))  # REM -> REM
+    rw = np.sum((stages[:-1] == 'REM') & (stages[1:] == 'WAKE'))  # REM -> Wake
+    rn = np.sum((stages[:-1] == 'REM') & (stages[1:] == 'NREM'))  # REM -> NREM
+
+    wr = np.sum((stages[:-1] == 'WAKE') & (stages[1:] == 'REM'))  # Wake -> REM
+    ww = np.sum((stages[:-1] == 'WAKE') &
+                (stages[1:] == 'WAKE'))  # Wake-> Wake
+    wn = np.sum((stages[:-1] == 'WAKE') &
+                (stages[1:] == 'NREM'))  # Wake-> NREM
+
+    nr = np.sum((stages[:-1] == 'NREM') & (stages[1:] == 'REM'))  # NREM -> REM
+    nw = np.sum((stages[:-1] == 'NREM') &
+                (stages[1:] == 'WAKE'))  # NREM -> Wake
+    nn = np.sum((stages[:-1] == 'NREM') &
+                (stages[1:] == 'NREM'))  # NREM -> NREM
+
+    s_trans = rr + rw + rn + nr + nw + nn
+    w_trans = wr + ww + wn
+    swtrans = np.array([(rw+nw)/s_trans, (wn+wr)/w_trans])  # Psw, Pws
+
+    return swtrans
+
+
+def swtrans_from_stage_sss_style(stage_call, epoch_len_sec):
+    # filter the stage call
+    stage_call_f = filter_short_bout(stage_call)
+
+    # convert to sleep / wake label
+    # OUTLIER1,2 are labels used in SSS
+    sw_call = np.array(['SLEEP' if (x == 'NREM' or x == 'REM' or x == 'SLEEP')
+                        else 'WAKE' if (x != 'UNKNOWN' and x != 'OUTLIER1' and x != 'OUTLIER2')
+                        else 'UNKNOWN' for x in stage_call_f])
+
+    # transitions array
+    tsw = (sw_call[:-1] == 'SLEEP') & (sw_call[1:] == 'WAKE')  # SLEEP -> WAKE
+    tss = (sw_call[:-1] == 'SLEEP') & (sw_call[1:] == 'SLEEP') # SLEEP -> SLEEP
+    tws = (sw_call[:-1] == 'WAKE') & (sw_call[1:] == 'SLEEP')  # WAKE -> WAKE
+    tww = (sw_call[:-1] == 'WAKE') & (sw_call[1:] == 'WAKE')   # WAKE -> WAKE
+    tsw = np.append(tsw, 0)
+    tss = np.append(tss, 0)
+    tws = np.append(tws, 0)
+    tww = np.append(tww, 0)
+
+    # transition binary matrix
+    ## 24 hours(86400 sec) bin
+    tsw_mat_day = tsw.reshape(-1, int(86400/epoch_len_sec))
+    tss_mat_day = tss.reshape(-1, int(86400/epoch_len_sec))
+    tws_mat_day = tws.reshape(-1, int(86400/epoch_len_sec))
+    tww_mat_day = tww.reshape(-1, int(86400/epoch_len_sec))
+    ## 12 hours(43200 sec) bin
+    tsw_mat_halfday = tsw.reshape(-1, int(43200/epoch_len_sec))
+    tss_mat_halfday = tss.reshape(-1, int(43200/epoch_len_sec))
+    tws_mat_halfday = tws.reshape(-1, int(43200/epoch_len_sec))
+    tww_mat_halfday = tww.reshape(-1, int(43200/epoch_len_sec))
+
+    # first & second halfday
+    n_halfday = tsw_mat_halfday.shape[0]
+    tsw_mat_halfday_first = tsw_mat_halfday[np.arange(0, n_halfday, 2), :] # first half day
+    tss_mat_halfday_first = tss_mat_halfday[np.arange(0, n_halfday, 2), :]
+    tws_mat_halfday_first = tws_mat_halfday[np.arange(0, n_halfday, 2), :]
+    tww_mat_halfday_first = tww_mat_halfday[np.arange(0, n_halfday, 2), :]
+    tsw_mat_halfday_second = tsw_mat_halfday[np.arange(1, n_halfday, 2), :] # second half day
+    tss_mat_halfday_second = tss_mat_halfday[np.arange(1, n_halfday, 2), :]
+    tws_mat_halfday_second = tws_mat_halfday[np.arange(1, n_halfday, 2), :]
+    tww_mat_halfday_second = tww_mat_halfday[np.arange(1, n_halfday, 2), :]
+
+    # transition count array
+    daily_nsw = np.apply_along_axis(np.sum, 1, tsw_mat_day)
+    daily_nss = np.apply_along_axis(np.sum, 1, tss_mat_day)
+    daily_nws = np.apply_along_axis(np.sum, 1, tws_mat_day)
+    daily_nww = np.apply_along_axis(np.sum, 1, tww_mat_day)
+    halfdaily_first_nsw = np.apply_along_axis(np.sum, 1, tsw_mat_halfday_first)
+    halfdaily_first_nss = np.apply_along_axis(np.sum, 1, tss_mat_halfday_first)
+    halfdaily_first_nws = np.apply_along_axis(np.sum, 1, tws_mat_halfday_first)
+    halfdaily_first_nww = np.apply_along_axis(np.sum, 1, tww_mat_halfday_first)
+    halfdaily_second_nsw = np.apply_along_axis(np.sum, 1, tsw_mat_halfday_second)
+    halfdaily_second_nss = np.apply_along_axis(np.sum, 1, tss_mat_halfday_second)
+    halfdaily_second_nws = np.apply_along_axis(np.sum, 1, tws_mat_halfday_second)
+    halfdaily_second_nww = np.apply_along_axis(np.sum, 1, tww_mat_halfday_second)
+
+    # time matrix
+    ## 24 hours(86400 sec) bin
+    sleep_epoch_mat_day = (sw_call == 'SLEEP').reshape(-1, int(86400/epoch_len_sec))
+    wake_epoch_mat_day = (sw_call == 'WAKE').reshape(-1, int(86400/epoch_len_sec))
+    ## 12 hours(43200 sec) bin
+    sleep_epoch_mat_halfday = (sw_call == 'SLEEP').reshape(-1, int(43200/epoch_len_sec))
+    wake_epoch_mat_halfday = (sw_call == 'WAKE').reshape(-1, int(43200/epoch_len_sec))
+
+    # daily and halfdaily time
+    daily_sleep_time = np.apply_along_axis(np.sum, 1, sleep_epoch_mat_day*epoch_len_sec/60)
+    daily_wake_time = np.apply_along_axis(np.sum, 1, wake_epoch_mat_day*epoch_len_sec/60)
+    halfdaily_sleep_time = np.apply_along_axis(
+        np.sum, 1, sleep_epoch_mat_halfday*epoch_len_sec/60)
+    halfdaily_wake_time = np.apply_along_axis(
+        np.sum, 1, wake_epoch_mat_halfday*epoch_len_sec/60)
+    halfdaily_first_sleep_time = halfdaily_sleep_time[np.arange(0, n_halfday, 2)]
+    halfdaily_first_wake_time = halfdaily_wake_time[np.arange(0, n_halfday, 2)]
+    halfdaily_second_sleep_time = halfdaily_sleep_time[np.arange(1, n_halfday, 2)]
+    halfdaily_second_wake_time = halfdaily_wake_time[np.arange(1, n_halfday, 2)]
+
+    # all .day
+    pswpws_all_day = _calc_sss_style_trans(daily_nsw, daily_nss,
+                                           daily_nws, daily_nww,
+                                           daily_sleep_time, daily_wake_time)
+    # first halfday
+    pswpws_halfday_first = _calc_sss_style_trans(halfdaily_first_nsw, halfdaily_first_nss, 
+                                                 halfdaily_first_nws, halfdaily_first_nww, 
+                                                 halfdaily_first_sleep_time, halfdaily_first_wake_time)
+    #second halfday
+    pswpws_halfday_second = _calc_sss_style_trans(halfdaily_second_nsw, halfdaily_second_nss, 
+                                                  halfdaily_second_nws, halfdaily_second_nww, 
+                                                  halfdaily_second_sleep_time, halfdaily_second_wake_time)
+
+    return {'all_day':pswpws_all_day, 'first_halfday':pswpws_halfday_first, 'second_halfday':pswpws_halfday_second}
+
+
+def _calc_sss_style_trans(nsw, nss, nws, nww, st, wt):
+    denom_sw = np.array(nss + nsw, np.float64)
+    denom_ws = np.array(nww + nws, np.float64)
+    denom_sw[denom_sw == 0] = np.nan
+    denom_ws[denom_ws == 0] = np.nan
+
+    _psw = nsw/denom_sw
+    _pws = nws/denom_ws
+    psw = np.sum(_psw*st)/np.sum(st)
+    pws = np.sum(_pws*wt)/np.sum(wt)
+
+    return (psw, pws)
+
+
+def swtrans_profile(stage_call, epoch_len_sec):
+    """ Profile (two timeseries) of the hourly Psw and Psw
+
+    Args:
+        stage_call (np.array(1)): an array of stage calls (e.g. ['WAKE',
+        'NREM', ...])
+
+    Returns:
+        [np.array(1), np.array(1)]: a list of two np.arrays. Each array contain Psw and Pws.
+    """
+    stage_call = np.array(['SLEEP' if (x == 'NREM' or x == 'REM')
+                           else 'WAKE' if x != 'UNKNOWN' else 'UNKNOWN' for x in stage_call])
+
+    tsw = (stage_call[:-1] == 'SLEEP') & (stage_call[1:] == 'WAKE')  # SLEEP -> WAKE
+    tss = (stage_call[:-1] == 'SLEEP') & (stage_call[1:] == 'SLEEP') # SLEEP -> SLEEP
+    tws = (stage_call[:-1] == 'WAKE') & (stage_call[1:] == 'SLEEP')  # WAKE -> WAKE
+    tww = (stage_call[:-1] == 'WAKE') & (stage_call[1:] == 'WAKE')   # WAKE -> WAKE
+    tsw = np.append(tsw, 0)
+    tss = np.append(tss, 0)
+    tws = np.append(tws, 0)
+    tww = np.append(tww, 0)
+
+    tsw_mat = tsw.reshape(-1, int(3600/epoch_len_sec))  # 60 min(3600 sec) bin
+    tss_mat = tss.reshape(-1, int(3600/epoch_len_sec))
+    tws_mat = tws.reshape(-1, int(3600/epoch_len_sec))
+    tww_mat = tww.reshape(-1, int(3600/epoch_len_sec))
+
+    hourly_tsw = np.apply_along_axis(np.sum, 1, tsw_mat) 
+    hourly_tss = np.apply_along_axis(np.sum, 1, tss_mat) 
+    hourly_tws = np.apply_along_axis(np.sum, 1, tws_mat) 
+    hourly_tww = np.apply_along_axis(np.sum, 1, tww_mat) 
+
+    denom = np.array(hourly_tss+hourly_tsw, dtype=np.float64)
+    denom[denom==0] = np.nan
+    hourly_psw = hourly_tsw/denom
+
+    denom = np.array(hourly_tww+hourly_tws, dtype=np.float64)
+    denom[denom==0] = np.nan
+    hourly_pws = hourly_tws/denom
+
+    return [hourly_psw, hourly_pws]
+
+
+def bout_table(stage_call):
+    """ 
+    Args:
+        stage_call (np.array(1)): An array of stage calls such as ['WAKE', 'NREM', 'REM', ...].
+        This function works with any set of stage calls.
+
+    Returns:
+        pd.DataFrame({'stage':, 'len':, 'start_idx':}): A DataFrame of 3 columms of bouts.
+        Each row tells what stage, how long, and the epoch index where the bout starts.
+    """
+    epoch_len = len(stage_call)
+
+    bidx_trans = stage_call[0:(epoch_len-1)] != stage_call[1:epoch_len]
+    bidx_trans = np.append(True, bidx_trans) # the first epoch is always True
+
+    idx_trans = np.where(bidx_trans)[0]
+    bout_len = idx_trans[1:len(idx_trans)] - idx_trans[0:(len(idx_trans)-1)]
+    bout_len = np.append(bout_len, epoch_len - idx_trans[len(idx_trans)-1])
+    bout_stage = stage_call[bidx_trans]
+
+    bout_df = pd.DataFrame({'stage':bout_stage, 'len':bout_len, 'start_idx':idx_trans})
+
+    return bout_df
+
+def filter_short_bout(stage_call, min_bout_len=2):
+    """ Removes short bouts of stage.
+    Args:
+        stage_call (np.arra(1)): An array of stages.
+        min_bout_len (int, optional): Bouts shorter than this value are to be removed. Defaults to 2.
+        Note: The removal overwrites the short bouts by the adjacent previous epoch's stage.
+
+    Returns:
+        np.array(1): An array of stages without the short bouts.
+    """
+    bout_df = bout_table(stage_call)
+
+    bidx_cond = bout_df['len'] < min_bout_len
+
+    stage_call_filtered = stage_call.copy()
+    for _, r in bout_df[bidx_cond].iterrows():
+        start_idx = r['start_idx']
+        bout_len = r['len']
+        if start_idx == 0:
+            cover_call = stage_call_filtered[start_idx + bout_len]
+        else:
+            cover_call = stage_call_filtered[start_idx - 1]
+        stage_call_filtered[start_idx:(start_idx+bout_len)] = str(cover_call) # str() is to avoid UnicodeDecodeError probably related to the broadcasting
+
+    return stage_call_filtered
+
+
+def _set_common_features_stagetime_profile(ax, x_max):
+    ax.set_yticks([0, 20, 40, 60])
+    ax.set_xticks(np.arange(0, x_max+1, 6))
+    ax.grid(dashes=(2, 2))
+
+    light_bar_base = matplotlib.patches.Rectangle(
+        xy=[0, -8], width=x_max, height=6, fill=True, color=stage.COLOR_DARK)
+    ax.add_patch(light_bar_base)
+    for day in range(int(x_max/24)):
+        light_bar_light = matplotlib.patches.Rectangle(
+            xy=[24*day, -8], width=12, height=6, fill=True, color=stage.COLOR_LIGHT)
+        ax.add_patch(light_bar_light)
+
+    ax.set_ylim(-10, 70)
+
+
+def _set_common_features_swtrans_profile(ax, x_max):
+    ax.set_yticks([0, 0.1, 0.2, 0.3, 0.4, 0.5])
+    ax.set_xticks(np.arange(0, x_max+1, 6))
+    ax.grid(dashes=(2, 2))
+
+    light_bar_base = matplotlib.patches.Rectangle(
+        xy=[0, -0.08], width=x_max, height=0.06, fill=True, color=stage.COLOR_DARK)
+    ax.add_patch(light_bar_base)
+    for day in range(int(x_max/24)):
+        light_bar_light = matplotlib.patches.Rectangle(
+            xy=[24*day, -0.08], width=12, height=0.06, fill=True, color=stage.COLOR_LIGHT)
+        ax.add_patch(light_bar_light)
+
+    ax.set_ylim(-0.1, 0.5)
+
+
+def _set_common_features_stagetime_profile_rem(ax, x_max):
+    r = 4  # a scale factor for y-axis
+    ax.set_yticks(np.array([0, 20, 40, 60])/r)
+    ax.set_xticks(np.arange(0, x_max+1, 6))
+    ax.grid(dashes=(2, 2))
+
+    light_bar_base = matplotlib.patches.Rectangle(
+        xy=[0, -8/r], width=x_max, height=6/r, fill=True, color=stage.COLOR_DARK)
+    ax.add_patch(light_bar_base)
+    for day in range(int(x_max/24)):
+        light_bar_light = matplotlib.patches.Rectangle(
+            xy=[24*day, -8/4], width=12, height=6/r, fill=True, color=stage.COLOR_LIGHT)
+        ax.add_patch(light_bar_light)
+
+    ax.set_ylim(-10/r, 70/r)
+
+
+
+def draw_stagetime_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    stagetime_profile_list = stagetime_stats['stagetime_profile']
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    x_max = epoch_num*epoch_len_sec/3600
+    x = np.arange(x_max)
+    for i, profile in enumerate(stagetime_profile_list):
+        fig = Figure(figsize=(13, 6))
+        ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
+        ax3 = fig.add_subplot(313, xmargin=0, ymargin=0)
+        _set_common_features_stagetime_profile_rem(ax1, x_max)
+        _set_common_features_stagetime_profile(ax2, x_max)
+        _set_common_features_stagetime_profile(ax3, x_max)
+
+        ax1.set_ylabel('Hourly REM\n duration (min)')
+        ax2.set_ylabel('Hourly NREM\n duration (min)')
+        ax3.set_ylabel('Hourly wake\n duration (min)')
+        ax3.set_xlabel('Time (hours)')
+
+        ax1.plot(x, profile[0, :], color=stage.COLOR_REM)
+        ax2.plot(x, profile[1, :], color=stage.COLOR_NREM)
+        ax3.plot(x, profile[2, :], color=stage.COLOR_WAKE)
+
+        fig.suptitle(
+            f'Stage-time profile: {"  ".join(stagetime_df.iloc[i,0:4].values)}')
+        filename = f'stage-time_profile_I_{"_".join(stagetime_df.iloc[i,0:4].values)}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    stagetime_profile_list = stagetime_stats['stagetime_profile']
+
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # make stats of stagetime profile: mean and sd over each group
+    stagetime_profile_mat = np.array(stagetime_profile_list)  # REM, NREM, Wake
+    stagetime_profile_stats_list = []
+    for bidx in bidx_group_list:
+        stagetime_profile_mean = np.apply_along_axis(
+            np.mean, 0, stagetime_profile_mat[bidx])
+        stagetime_profile_sd = np.apply_along_axis(
+            np.std, 0, stagetime_profile_mat[bidx])
+        stagetime_profile_stats_list.append(
+            np.array([stagetime_profile_mean, stagetime_profile_sd]))
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    x_max = epoch_num*epoch_len_sec/3600
+    x = np.arange(x_max)
+    if len(mouse_groups_set) > 1:
+        # contrast to group index = 0
+        for g_idx in range(1, len(mouse_groups_set)):
+            csv_df = pd.DataFrame()
+            mgs_c = mouse_groups_set[0] # control
+            mgs_t = mouse_groups_set[g_idx] # treatment
+            num = np.sum(bidx_group_list[g_idx])
+            fig = Figure(figsize=(13, 6))
+            ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
+            ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
+            ax3 = fig.add_subplot(313, xmargin=0, ymargin=0)
+
+            _set_common_features_stagetime_profile_rem(ax1, x_max)
+            _set_common_features_stagetime_profile(ax2, x_max)
+            _set_common_features_stagetime_profile(ax3, x_max)
+
+            # Control (always the first group)
+            num_c = np.sum(bidx_group_list[0])
+            # REM
+            y = stagetime_profile_stats_list[0][0, 0, :]
+            y_sem = stagetime_profile_stats_list[0][1, 0, :]/np.sqrt(num_c)
+            csv_df = pd.DataFrame({'Time':x, f'{mgs_c}_REM_mean':y, f'{mgs_c}_REM_SEM':y_sem})
+            ax1.plot(x, y, color='grey')
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+            ax1.set_ylabel('Hourly REM\n duration (min)')
+
+            # NREM
+            y = stagetime_profile_stats_list[0][0, 1, :]
+            y_sem = stagetime_profile_stats_list[0][1, 1, :]/np.sqrt(num_c)
+            csv_df = pd.concat([csv_df, pd.DataFrame(
+                {f'{mgs_c}_NREM_mean': y, f'{mgs_c}_NREM_SEM': y_sem})], axis=1)
+            ax2.plot(x, y, color='grey')
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+            ax2.set_ylabel('Hourly NREM\n duration (min)')
+
+            # Wake
+            y = stagetime_profile_stats_list[0][0, 2, :]
+            y_sem = stagetime_profile_stats_list[0][1, 2, :]/np.sqrt(num_c)
+            csv_df = pd.concat([csv_df, pd.DataFrame(
+                {f'{mgs_c}_Wake_mean': y, f'{mgs_c}_Wake_SEM': y_sem})], axis=1)
+            ax3.plot(x, y, color='grey')
+            ax3.fill_between(x, y - y_sem/np.sqrt(num),
+                             y + y_sem/np.sqrt(num), color='grey', alpha=0.3)
+            ax3.set_ylabel('Hourly wake\n duration (min)')
+            ax3.set_xlabel('Time (hours)')
+
+            # Treatment
+            num = np.sum(bidx_group_list[g_idx])
+            # REM
+            y = stagetime_profile_stats_list[g_idx][0, 0, :]
+            y_sem = stagetime_profile_stats_list[g_idx][1, 0, :]/np.sqrt(num)
+            csv_df = pd.concat([csv_df, pd.DataFrame(
+                {f'{mgs_t}_REM_mean': y, f'{mgs_t}_REM_SEM': y_sem})], axis=1)
+            ax1.plot(x, y, color=stage.COLOR_REM)
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_REM, alpha=0.3)
+
+            # NREM
+            y = stagetime_profile_stats_list[g_idx][0, 1, :]
+            y_sem = stagetime_profile_stats_list[g_idx][1, 1, :]/np.sqrt(num)
+            csv_df = pd.concat([csv_df, pd.DataFrame(
+                {f'{mgs_t}_NREM_mean': y, f'{mgs_t}_NREM_SEM': y_sem})], axis=1)
+            ax2.plot(x, y, color=stage.COLOR_NREM)
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+            # Wake
+            y = stagetime_profile_stats_list[g_idx][0, 2, :]
+            y_sem = stagetime_profile_stats_list[g_idx][1, 2, :]/np.sqrt(num)
+            csv_df = pd.concat([csv_df, pd.DataFrame(
+                {f'{mgs_c}_Wake_mean': y, f'{mgs_c}_Wake_SEM': y_sem})], axis=1)
+            ax3.plot(x, y, color=stage.COLOR_WAKE)
+            ax3.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+
+            fig.suptitle(
+                f'{mgs_c} (n={num_c}) v.s. {mgs_t} (n={num})')
+            filename = f'stage-time_profile_G_{mgs_c}_vs_{mgs_t}'
+            sc.savefig(output_dir, filename, fig)
+            csv_df.to_csv(os.path.join(output_dir, f'{filename}.csv'), index=False)
+    else:
+        # single group
+        g_idx = 0
+
+        csv_df = pd.DataFrame()
+        mgs_t = mouse_groups_set[g_idx] # treatment
+        num = np.sum(bidx_group_list[g_idx])
+        x_max = epoch_num*epoch_len_sec/3600
+        x = np.arange(x_max)
+        fig = Figure(figsize=(13, 6))
+        ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
+        ax3 = fig.add_subplot(313, xmargin=0, ymargin=0)
+
+        _set_common_features_stagetime_profile_rem(ax1, x_max)
+        _set_common_features_stagetime_profile(ax2, x_max)
+        _set_common_features_stagetime_profile(ax3, x_max)
+
+        # REM
+        y = stagetime_profile_stats_list[g_idx][0, 0, :]
+        y_sem = stagetime_profile_stats_list[g_idx][1, 0, :]/np.sqrt(num)
+        csv_df = pd.DataFrame({'Time':x, f'{mgs_t}_REM_mean':y, f'{mgs_t}_REM_SEM':y_sem})
+        ax1.plot(x, y, color=stage.COLOR_REM)
+        ax1.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_REM, alpha=0.3)
+        ax1.set_ylabel('Hourly REM\n duration (min)')
+
+        # NREM
+        y = stagetime_profile_stats_list[g_idx][0, 1, :]
+        y_sem = stagetime_profile_stats_list[g_idx][1, 1, :]/np.sqrt(num)
+        csv_df = pd.concat([csv_df, pd.DataFrame(
+            {f'{mgs_t}_NREM_mean': y, f'{mgs_t}_NREM_SEM': y_sem})], axis=1)
+        ax2.plot(x, y, color=stage.COLOR_NREM)
+        ax2.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+        ax2.set_ylabel('Hourly NREM\n duration (min)')
+
+        # Wake
+        y = stagetime_profile_stats_list[g_idx][0, 2, :]
+        y_sem = stagetime_profile_stats_list[g_idx][1, 2, :]/np.sqrt(num)
+        csv_df = pd.concat([csv_df, pd.DataFrame(
+            {f'{mgs_t}_Wake_mean': y, f'{mgs_t}_Wake_SEM': y_sem})], axis=1)
+        ax3.plot(x, y, color=stage.COLOR_WAKE)
+        ax3.fill_between(x, y - y_sem/np.sqrt(num),
+                         y + y_sem/np.sqrt(num), color=stage.COLOR_WAKE, alpha=0.3)
+        ax3.set_ylabel('Hourly wake\n duration (min)')
+        ax3.set_xlabel('Time (hours)')
+
+        fig.suptitle(f'{mgs_t} (n={num})')
+        filename = f'stage-time_profile_G_{mgs_t}'
+        sc.savefig(output_dir, filename, fig)
+        csv_df.to_csv(os.path.join(output_dir, f'{filename}.csv'), index=False)
+
+
+def draw_swtrans_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    swtrans_profile_list = stagetime_stats['swtrans_profile']
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    x_max = epoch_num*epoch_len_sec/3600
+    x = np.arange(x_max)
+    for i, profile in enumerate(swtrans_profile_list):
+        fig = Figure(figsize=(13, 6))
+        ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(212, xmargin=0, ymargin=0)
+        _set_common_features_swtrans_profile(ax1, x_max)
+        _set_common_features_swtrans_profile(ax2, x_max)
+
+        ax1.set_ylabel('Hourly Psw')
+        ax2.set_ylabel('Hourly Pws')
+        ax2.set_xlabel('Time (hours)')
+
+        ax1.plot(x, profile[0], color=stage.COLOR_NREM)
+        ax2.plot(x, profile[1], color=stage.COLOR_WAKE)
+
+        fig.suptitle(
+            f'Sleep-wake transition (Psw Pws) profile:\n{"  ".join(stagetime_df.iloc[i,0:4].values)}')
+        filename = f'sleep-wake-transition_profile_I_{"_".join(stagetime_df.iloc[i,0:4].values)}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    swtrans_profile_list = stagetime_stats['swtrans_profile']
+
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # make stats of stagetime profile: mean and sd over each group
+    swtrans_profile_mat = np.array(swtrans_profile_list)  # Psw, Pws
+    swtrans_profile_stats_list = []
+    for bidx in bidx_group_list:
+        # "RuntimeWarning: Mean of empty slice" may occure here and safely ignorable
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            swtrans_profile_mean = np.apply_along_axis(
+                np.nanmean, 0, swtrans_profile_mat[bidx])
+            swtrans_profile_sd = np.apply_along_axis(
+                np.nanstd, 0, swtrans_profile_mat[bidx])
+            swtrans_profile_stats_list.append(
+                np.array([swtrans_profile_mean, swtrans_profile_sd]))
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    x_max = epoch_num*epoch_len_sec/3600
+    x = np.arange(x_max)
+    if len(mouse_groups_set) > 1:
+        # contrast to group index = 0
+        for g_idx in range(1, len(mouse_groups_set)):
+            num = np.sum(bidx_group_list[g_idx])
+            fig = Figure(figsize=(13, 6))
+            ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
+            ax2 = fig.add_subplot(212, xmargin=0, ymargin=0)
+
+            _set_common_features_swtrans_profile(ax1, x_max)
+            _set_common_features_swtrans_profile(ax2, x_max)
+            ax2.set_xlabel('Time (hours)')
+
+            # Control (always the first group)
+            num_c = np.sum(bidx_group_list[0])
+            # Psw
+            y = swtrans_profile_stats_list[0][0, 0, :]
+            y_sem = swtrans_profile_stats_list[0][1, 0, :]/np.sqrt(num_c)
+            ax1.plot(x, y, color='grey')
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+            ax1.set_ylabel('Hourly Psw')
+
+            # Pws
+            y = swtrans_profile_stats_list[0][0, 1, :]
+            y_sem = swtrans_profile_stats_list[0][1, 1, :]/np.sqrt(num_c)
+            ax2.plot(x, y, color='grey')
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+            ax2.set_ylabel('Hourly `Pws')
+
+            # Treatments
+            num = np.sum(bidx_group_list[g_idx])
+            # Psw
+            y = swtrans_profile_stats_list[g_idx][0, 0, :]
+            y_sem = swtrans_profile_stats_list[g_idx][1, 0, :]/np.sqrt(num)
+            ax1.plot(x, y, color=stage.COLOR_NREM)
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+            # Pws
+            y = swtrans_profile_stats_list[g_idx][0, 1, :]
+            y_sem = swtrans_profile_stats_list[g_idx][1, 1, :]/np.sqrt(num)
+            ax2.plot(x, y, color=stage.COLOR_WAKE)
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+
+            fig.suptitle(
+                f'Sleep-wake transition (Psw Pws) profile:\n{mouse_groups_set[0]} (n={num_c}) v.s. {mouse_groups_set[g_idx]} (n={num})')
+            filename = f'sleep-wake-transition_profile_G_{mouse_groups_set[0]}_vs_{mouse_groups_set[g_idx]}'
+            sc.savefig(output_dir, filename, fig)
+    else:
+        # single group
+        g_idx = 0
+
+        num = np.sum(bidx_group_list[g_idx])
+        x_max = epoch_num*epoch_len_sec/3600
+        x = np.arange(x_max)
+        fig = Figure(figsize=(13, 6))
+        ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(212, xmargin=0, ymargin=0)
+
+        _set_common_features_swtrans_profile(ax1, x_max)
+        _set_common_features_swtrans_profile(ax2, x_max)
+        ax2.set_xlabel('Time (hours)')
+ 
+        # Psw
+        y = swtrans_profile_stats_list[g_idx][0, 0, :]
+        y_sem = swtrans_profile_stats_list[g_idx][1, 0, :]/np.sqrt(num)
+        ax1.plot(x, y, color=stage.COLOR_NREM)
+        ax1.fill_between(x, y - y_sem,
+                            y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+        # Pws
+        y = swtrans_profile_stats_list[g_idx][0, 1, :]
+        y_sem = swtrans_profile_stats_list[g_idx][1, 1, :]/np.sqrt(num)
+        ax2.plot(x, y, color=stage.COLOR_WAKE)
+        ax2.fill_between(x, y - y_sem,
+                            y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+        ax2.set_xlabel('Time (hours)')
+
+        fig.suptitle(f'Sleep-wake transition (Psw Pws) profile:\n{mouse_groups_set[g_idx]} (n={num})')
+        filename = f'sleep-wake-transition_profile_G_{mouse_groups_set[g_idx]}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def draw_stagetime_circadian_profile_indiviudal(stagetime_stats, epoch_len_sec, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    stagetime_circadian_list = stagetime_stats['stagetime_circadian']
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    for i, circadian in enumerate(stagetime_circadian_list):
+        x_max = 24
+        x = np.arange(x_max)
+        fig = Figure(figsize=(13, 4))
+        fig.subplots_adjust(wspace=0.3)
+        ax1 = fig.add_subplot(131, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(132, xmargin=0, ymargin=0)
+        ax3 = fig.add_subplot(133, xmargin=0, ymargin=0)
+
+        _set_common_features_stagetime_profile_rem(ax1, x_max)
+        _set_common_features_stagetime_profile(ax2, x_max)
+        _set_common_features_stagetime_profile(ax3, x_max)
+        ax1.set_xlabel('Time (hours)')
+        ax2.set_xlabel('Time (hours)')
+        ax3.set_xlabel('Time (hours)')
+        ax1.set_ylabel('Hourly REM\n duration (min)')
+        ax2.set_ylabel('Hourly NREM\n duration (min)')
+        ax3.set_ylabel('Hourly wake\n duration (min)')
+
+        num = epoch_num*epoch_len_sec/3600/24
+
+        # REM
+        y = circadian[0, 0, :]
+        y_sem = circadian[1, 0, :]/np.sqrt(num)
+        ax1.plot(x, y, color=stage.COLOR_REM)
+        ax1.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_REM, alpha=0.3)
+
+        # NREM
+        y = circadian[0, 1, :]
+        y_sem = circadian[1, 1, :]/np.sqrt(num)
+        ax2.plot(x, y, color=stage.COLOR_NREM)
+        ax2.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+        # Wake
+        y = circadian[0, 2, :]
+        y_sem = circadian[1, 2, :]/np.sqrt(num)
+        ax3.plot(x, y, color=stage.COLOR_WAKE)
+        ax3.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+
+        fig.suptitle(
+            f'Circadian stage-time profile: {"  ".join(stagetime_df.iloc[i,0:4].values)}')
+        filename = f'stage-time_circadian_profile_I_{"_".join(stagetime_df.iloc[i,0:4].values)}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def draw_stagetime_circadian_profile_grouped(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    stagetime_circadian_profile_list = stagetime_stats['stagetime_circadian']
+
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # make stats of stagetime circadian profile: mean and sd over each group
+    # mouse x [mean of REM, NREM, Wake] x 24 hours
+    stagetime_circadian_profile_mat = np.array(
+        [ms[0] for ms in stagetime_circadian_profile_list])
+    stagetime_circadian_profile_stats_list = []
+    for bidx in bidx_group_list:
+        stagetime_circadian_profile_mean = np.apply_along_axis(
+            np.mean, 0, stagetime_circadian_profile_mat[bidx])
+        stagetime_circadian_profile_sd = np.apply_along_axis(
+            np.std, 0, stagetime_circadian_profile_mat[bidx])
+        stagetime_circadian_profile_stats_list.append(
+            np.array([stagetime_circadian_profile_mean, stagetime_circadian_profile_sd]))
+
+    x_max = 24
+    x = np.arange(x_max)
+    if len(mouse_groups_set) > 1:
+        for g_idx in range(1, len(mouse_groups_set)):
+            fig = Figure(figsize=(13, 4))
+            fig.subplots_adjust(wspace=0.3)
+            ax1 = fig.add_subplot(131, xmargin=0, ymargin=0)
+            ax2 = fig.add_subplot(132, xmargin=0, ymargin=0)
+            ax3 = fig.add_subplot(133, xmargin=0, ymargin=0)
+
+            _set_common_features_stagetime_profile_rem(ax1, x_max)
+            _set_common_features_stagetime_profile(ax2, x_max)
+            _set_common_features_stagetime_profile(ax3, x_max)
+            ax1.set_xlabel('Time (hours)')
+            ax2.set_xlabel('Time (hours)')
+            ax3.set_xlabel('Time (hours)')
+            ax1.set_ylabel('Hourly REM\n duration (min)')
+            ax2.set_ylabel('Hourly NREM\n duration (min)')
+            ax3.set_ylabel('Hourly wake\n duration (min)')
+
+            # Control (always the first group)
+            num_c = np.sum(bidx_group_list[0])
+            # REM
+            y = stagetime_circadian_profile_stats_list[0][0, 0, :]
+            y_sem = stagetime_circadian_profile_stats_list[0][1, 0, :]/np.sqrt(
+                num_c)
+            ax1.plot(x, y, color='grey')
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+
+            # NREM
+            y = stagetime_circadian_profile_stats_list[0][0, 1, :]
+            y_sem = stagetime_circadian_profile_stats_list[0][1, 1, :]/np.sqrt(
+                num_c)
+            ax2.plot(x, y, color='grey')
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+
+            # Wake
+            y = stagetime_circadian_profile_stats_list[0][0, 2, :]
+            y_sem = stagetime_circadian_profile_stats_list[0][1, 2, :]/np.sqrt(
+                num_c)
+            ax3.plot(x, y, color='grey')
+            ax3.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+
+            # Treatment
+            num = np.sum(bidx_group_list[g_idx])
+            # REM
+            y = stagetime_circadian_profile_stats_list[g_idx][0, 0, :]
+            y_sem = stagetime_circadian_profile_stats_list[g_idx][1, 0, :]/np.sqrt(
+                num)
+            ax1.plot(x, y, color=stage.COLOR_REM)
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_REM, alpha=0.3)
+
+            # NREM
+            y = stagetime_circadian_profile_stats_list[g_idx][0, 1, :]
+            y_sem = stagetime_circadian_profile_stats_list[g_idx][1, 1, :]/np.sqrt(
+                num)
+            ax2.plot(x, y, color=stage.COLOR_NREM)
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+            # Wake
+            y = stagetime_circadian_profile_stats_list[g_idx][0, 2, :]
+            y_sem = stagetime_circadian_profile_stats_list[g_idx][1, 2, :]/np.sqrt(
+                num)
+            ax3.plot(x, y, color=stage.COLOR_WAKE)
+            ax3.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+
+            fig.suptitle(
+                f'{mouse_groups_set[0]} (n={num_c}) v.s. {mouse_groups_set[g_idx]} (n={num})')
+            filename = f'stage-time_circadian_profile_G_{mouse_groups_set[0]}_vs_{mouse_groups_set[g_idx]}'
+            sc.savefig(output_dir, filename, fig)
+    else:
+        # single group
+        g_idx = 0
+
+        num = np.sum(bidx_group_list[g_idx])
+        fig = Figure(figsize=(13, 4))
+        fig.subplots_adjust(wspace=0.3)
+        ax1 = fig.add_subplot(131, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(132, xmargin=0, ymargin=0)
+        ax3 = fig.add_subplot(133, xmargin=0, ymargin=0)
+
+
+        _set_common_features_stagetime_profile_rem(ax1, x_max)
+        _set_common_features_stagetime_profile(ax2, x_max)
+        _set_common_features_stagetime_profile(ax3, x_max)
+
+        # REM
+        y = stagetime_circadian_profile_stats_list[g_idx][0, 0, :]
+        y_sem = stagetime_circadian_profile_stats_list[g_idx][1, 0, :]/np.sqrt(num)
+        ax1.plot(x, y, color=stage.COLOR_REM)
+        ax1.fill_between(x, y - y_sem,
+                            y + y_sem, color=stage.COLOR_REM, alpha=0.3)
+        ax1.set_ylabel('Hourly REM\n duration (min)')
+
+        # NREM
+        y = stagetime_circadian_profile_stats_list[g_idx][0, 1, :]
+        y_sem = stagetime_circadian_profile_stats_list[g_idx][1, 1, :]/np.sqrt(num)
+        ax2.plot(x, y, color=stage.COLOR_NREM)
+        ax2.fill_between(x, y - y_sem,
+                            y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+        ax2.set_ylabel('Hourly NREM\n duration (min)')
+
+        # Wake
+        y = stagetime_circadian_profile_stats_list[g_idx][0, 2, :]
+        y_sem = stagetime_circadian_profile_stats_list[g_idx][1, 2, :]/np.sqrt(num)
+        ax3.plot(x, y, color=stage.COLOR_WAKE)
+        ax3.fill_between(x, y - y_sem/np.sqrt(num),
+                            y + y_sem/np.sqrt(num), color=stage.COLOR_WAKE, alpha=0.3)
+        ax3.set_ylabel('Hourly wake\n duration (min)')
+        ax3.set_xlabel('Time (hours)')
+
+        fig.suptitle(f'{mouse_groups_set[g_idx]} (n={num})')
+        filename = f'stage-time_circadian_profile_G_{mouse_groups_set[g_idx]}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def draw_swtrans_circadian_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    swtrans_circadian_list = stagetime_stats['swtrans_circadian']
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    for i, circadian in enumerate(swtrans_circadian_list):
+        x_max = 24
+        x = np.arange(x_max)
+        fig = Figure(figsize=(13, 4))
+        fig.subplots_adjust(wspace=0.3)
+        ax1 = fig.add_subplot(121, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(122, xmargin=0, ymargin=0)
+
+        _set_common_features_swtrans_profile(ax1, x_max)
+        _set_common_features_swtrans_profile(ax2, x_max)
+        ax1.set_xlabel('Time (hours)')
+        ax2.set_xlabel('Time (hours)')
+        ax1.set_ylabel('Hourly Psw')
+        ax2.set_ylabel('Hourly Pws')
+
+        num = epoch_num*epoch_len_sec/3600/24
+
+        # Psw
+        y = circadian[0, 0, :]
+        y_sem = circadian[1, 0, :]/np.sqrt(num)
+        ax1.plot(x, y, color=stage.COLOR_NREM)
+        ax1.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+        # Pws
+        y = circadian[0, 1, :]
+        y_sem = circadian[1, 1, :]/np.sqrt(num)
+        ax2.plot(x, y, color=stage.COLOR_WAKE)
+        ax2.fill_between(x, y - y_sem,
+                         y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+        fig.suptitle(
+            f'Circadian sleep-wake-transition profile: {"  ".join(stagetime_df.iloc[i,0:4].values)}')
+        filename = f'sleep-wake-transition_circadian_profile_I_{"_".join(stagetime_df.iloc[i,0:4].values)}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def draw_swtrans_circadian_profile_grouped(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    swtrans_circadian_profile_list = stagetime_stats['swtrans_circadian']
+
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # make stats of stagetime circadian profile: mean and sd over each group
+    # mouse x [mean of Psw, Pws] x 24 hours
+    swtrans_circadian_profile_mat = np.array(
+        [ms[0] for ms in swtrans_circadian_profile_list])
+    swtrans_circadian_profile_stats_list = []
+    for bidx in bidx_group_list:
+        # "RuntimeWarning: Mean of empty slice" may occur here and safely ignorable
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            swtrans_circadian_profile_mean = np.apply_along_axis(
+                np.nanmean, 0, swtrans_circadian_profile_mat[bidx])
+            swtrans_circadian_profile_sd = np.apply_along_axis(
+                np.nanstd, 0, swtrans_circadian_profile_mat[bidx])
+            swtrans_circadian_profile_stats_list.append(
+                np.array([swtrans_circadian_profile_mean, swtrans_circadian_profile_sd]))
+
+    x_max = 24
+    x = np.arange(x_max)
+    if len(mouse_groups_set) > 1:
+        for g_idx in range(1, len(mouse_groups_set)):
+            fig = Figure(figsize=(13, 4))
+            fig.subplots_adjust(wspace=0.3)
+            ax1 = fig.add_subplot(121, xmargin=0, ymargin=0)
+            ax2 = fig.add_subplot(122, xmargin=0, ymargin=0)
+
+            _set_common_features_swtrans_profile(ax1, x_max)
+            _set_common_features_swtrans_profile(ax2, x_max)
+            ax1.set_xlabel('Time (hours)')
+            ax2.set_xlabel('Time (hours)')
+            ax1.set_ylabel('Hourly Psw')
+            ax2.set_ylabel('Hourly Pws')
+
+            # Control (always the first group)
+            num_c = np.sum(bidx_group_list[0])
+            # Psw
+            y = swtrans_circadian_profile_stats_list[0][0, 0, :]
+            y_sem = swtrans_circadian_profile_stats_list[0][1, 0, :]/np.sqrt(
+                num_c)
+            ax1.plot(x, y, color='grey')
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+
+            # Pws
+            y = swtrans_circadian_profile_stats_list[0][0, 1, :]
+            y_sem = swtrans_circadian_profile_stats_list[0][1, 1, :]/np.sqrt(
+                num_c)
+            ax2.plot(x, y, color='grey')
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color='grey', alpha=0.3)
+
+            # Treatment
+            num = np.sum(bidx_group_list[g_idx])
+            # Psw
+            y = swtrans_circadian_profile_stats_list[g_idx][0, 0, :]
+            y_sem = swtrans_circadian_profile_stats_list[g_idx][1, 0, :]/np.sqrt(
+                num)
+            ax1.plot(x, y, color=stage.COLOR_NREM)
+            ax1.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+
+            # Pws
+            y = swtrans_circadian_profile_stats_list[g_idx][0, 1, :]
+            y_sem = swtrans_circadian_profile_stats_list[g_idx][1, 1, :]/np.sqrt(
+                num)
+            ax2.plot(x, y, color=stage.COLOR_WAKE)
+            ax2.fill_between(x, y - y_sem,
+                             y + y_sem, color=stage.COLOR_WAKE, alpha=0.3)
+
+            fig.suptitle(
+                f'{mouse_groups_set[0]} (n={num_c}) v.s. {mouse_groups_set[g_idx]} (n={num})')
+            filename = f'sleep-wake-transition_circadian_profile_G_{mouse_groups_set[0]}_vs_{mouse_groups_set[g_idx]}'
+            sc.savefig(output_dir, filename, fig)
+    else:
+        # single group
+        g_idx = 0
+
+        num = np.sum(bidx_group_list[g_idx])
+        fig = Figure(figsize=(13, 4))
+        fig.subplots_adjust(wspace=0.3)
+        ax1 = fig.add_subplot(121, xmargin=0, ymargin=0)
+        ax2 = fig.add_subplot(122, xmargin=0, ymargin=0)
+
+        _set_common_features_swtrans_profile(ax1, x_max)
+        _set_common_features_swtrans_profile(ax2, x_max)
+
+        # Psw
+        y = swtrans_circadian_profile_stats_list[g_idx][0, 0, :]
+        y_sem = swtrans_circadian_profile_stats_list[g_idx][1, 0, :]/np.sqrt(num)
+        ax1.plot(x, y, color=stage.COLOR_NREM)
+        ax1.fill_between(x, y - y_sem,
+                            y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+        ax1.set_ylabel('Hourly Psw')
+
+        # Pws
+        y = swtrans_circadian_profile_stats_list[g_idx][0, 1, :]
+        y_sem = swtrans_circadian_profile_stats_list[g_idx][1, 1, :]/np.sqrt(num)
+        ax2.plot(x, y, color=stage.COLOR_NREM)
+        ax2.fill_between(x, y - y_sem,
+                            y + y_sem, color=stage.COLOR_NREM, alpha=0.3)
+        ax2.set_ylabel('Hourly Pws')
+
+
+        fig.suptitle(f'{mouse_groups_set[g_idx]} (n={num})')
+        filename = f'sleep-wake-transition_circadian_profile_G_{mouse_groups_set[g_idx]}'
+        sc.savefig(output_dir, filename, fig)
+
+
+def x_shifts(values, y_min, y_max, width):
+    #    print_log(y_min, y_max)
+    counts, _ = np.histogram(values, range=(
+        np.min([y_min, np.min(values)]), np.max([y_max, np.max(values)])), bins=30)
+    sorted_values = sorted(values)
+    shifts = []
+#    print_log(counts)
+    non_zero_counts = counts[counts > 0]
+    for c in non_zero_counts:
+        if c == 1:
+            shifts.append(0)
+        else:
+            p = np.arange(1, c+1)  # point counts
+            s = np.repeat(p, 2)[:p.size] * (-1)**p * width / \
+                10  # [-1, 1, -2, 2, ...] * width/10
+            shifts.extend(s)
+
+#     print_log(shifts)
+#     print_log(sorted_values)
+    return [np.array(shifts), sorted_values]
+
+
+def scatter_datapoints(ax, w, x_pos, values):
+    s, v = x_shifts(values, *ax.get_ylim(), w)
+    ax.scatter(x_pos + s, v, color='darkgrey')
+
+
+def draw_stagetime_barchart(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+    num_groups = len(mouse_groups_set)
+
+    fig = Figure(figsize=(10, 4))
+    fig.subplots_adjust(wspace=0.5)
+    ax1 = fig.add_subplot(131)
+    ax2 = fig.add_subplot(132)
+    ax3 = fig.add_subplot(133)
+
+    w = 0.8  # bar width
+    x_pos = range(num_groups)
+    xtick_str_list = ['\n'.join(textwrap.wrap(mouse_groups_set[g_idx], 8))
+                      for g_idx in range(num_groups)]
+    ax1.set_xticks(x_pos)
+    ax2.set_xticks(x_pos)
+    ax3.set_xticks(x_pos)
+    ax1.set_xticklabels(xtick_str_list)
+    ax2.set_xticklabels(xtick_str_list)
+    ax3.set_xticklabels(xtick_str_list)
+    ax1.set_ylabel('REM duration (min)')
+    ax2.set_ylabel('NREM duration (min)')
+    ax3.set_ylabel('Wake duration (min)')
+
+    if num_groups > 1:
+        # REM
+        values_c = stagetime_df['REM'].values[bidx_group_list[0]]
+        mean_c = np.mean(values_c)
+        sem_c = np.std(values_c)/np.sqrt(len(values_c))
+        ax1.bar(x_pos[0], mean_c, yerr=sem_c, align='center',
+                width=w, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos[0], values_c)
+        for g_idx in range(1, num_groups):
+            values_t = stagetime_df['REM'].values[bidx_group_list[g_idx]]
+            mean_t = np.mean(values_t)
+            sem_t = np.std(values_t)/np.sqrt(len(values_t))
+            ax1.bar(x_pos[g_idx], mean_t, yerr=sem_t, align='center',
+                    width=w, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+            scatter_datapoints(ax1, w, x_pos[g_idx], values_t)
+
+        # NREM
+        values_c = stagetime_df['NREM'].values[bidx_group_list[0]]
+        mean_c = np.mean(values_c)
+        sem_c = np.std(values_c)/np.sqrt(len(values_c))
+        ax2.bar(x_pos[0], mean_c, yerr=sem_c, align='center',
+                width=w, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax2, w, x_pos[0], values_c)
+
+        for g_idx in range(1, num_groups):
+            values_t = stagetime_df['NREM'].values[bidx_group_list[g_idx]]
+            mean_t = np.mean(values_t)
+            sem_t = np.std(values_t)/np.sqrt(len(values_t))
+            ax2.bar(x_pos[g_idx], mean_t, yerr=sem_t, align='center',
+                    width=w, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+            scatter_datapoints(ax2, w, x_pos[g_idx], values_t)
+
+        # Wake
+        values_c = stagetime_df['Wake'].values[bidx_group_list[0]]
+        mean_c = np.mean(values_c)
+        sem_c = np.std(values_c)/np.sqrt(len(values_c))
+        ax3.bar(x_pos[0], mean_c, yerr=sem_c, align='center',
+                width=w, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax3, w, x_pos[0], values_c)
+
+        for g_idx in range(1, num_groups):
+            values_t = stagetime_df['Wake'].values[bidx_group_list[g_idx]]
+            mean_t = np.mean(values_t)
+            sem_t = np.std(values_t)/np.sqrt(len(values_t))
+            ax3.bar(x_pos[g_idx], mean_t, yerr=sem_t, align='center',
+                    width=w, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+            scatter_datapoints(ax3, w, x_pos[g_idx], values_t)
+    else:
+        # single group
+        g_idx = 0
+        # REM
+        values_t = stagetime_df['REM'].values[bidx_group_list[0]]
+        mean_t = np.mean(values_t)
+        sem_t = np.std(values_t)/np.sqrt(len(values_t))
+        ax1.bar(x_pos[g_idx], mean_t, yerr=sem_t, align='center',
+                width=w, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos[g_idx], values_t)
+
+        # NREM
+        values_t = stagetime_df['NREM'].values[bidx_group_list[0]]
+        mean_t = np.mean(values_t)
+        sem_t = np.std(values_t)/np.sqrt(len(values_t))
+        ax2.bar(x_pos[g_idx], mean_t, yerr=sem_t, align='center',
+                width=w, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+        scatter_datapoints(ax2, w, x_pos[g_idx], values_t)
+
+        # Wake
+        values_t = stagetime_df['Wake'].values[bidx_group_list[0]]
+        mean_t = np.mean(values_t)
+        sem_t = np.std(values_t)/np.sqrt(len(values_t))
+        ax3.bar(x_pos[g_idx], mean_t, yerr=sem_t, align='center',
+                width=w, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+        scatter_datapoints(ax3, w, x_pos[g_idx], values_t)
+
+    fig.suptitle('Stage-times')
+    filename = 'stage-time_barchart'
+    sc.savefig(output_dir, filename, fig)
+
+
+
+def _draw_transition_barchart(mouse_groups, transmat_mat):
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+    num_groups = len(mouse_groups_set)
+
+    fig = Figure(figsize=(12, 8))
+    fig.subplots_adjust(wspace=0.2)
+    ax1 = fig.add_subplot(221)
+    ax2 = fig.add_subplot(222)
+    ax3 = fig.add_subplot(223)
+    ax4 = fig.add_subplot(224)
+
+    w = 0.8  # bar width
+    w_sf = 2 / num_groups # scale factor for the bar width
+    ax1.set_xticks([0, 2, 4])
+    ax2.set_xticks([0, 2])
+    ax3.set_xticks([0, 2])
+    ax4.set_xticks([0, 2])
+    ax1.set_xticklabels(['RR', 'NN', 'WW'])
+    ax2.set_xticklabels(['RN', 'RW'])
+    ax3.set_xticklabels(['NR', 'NW'])
+    ax4.set_xticklabels(['WR', 'WN'])
+
+    # control group (always index: 0)
+    num_c = np.sum(bidx_group_list[0])
+    rr_vals_c = transmat_mat[bidx_group_list[0]][:, 0, 0]
+    ww_vals_c = transmat_mat[bidx_group_list[0]][:, 1, 1]
+    nn_vals_c = transmat_mat[bidx_group_list[0]][:, 2, 2]
+    rw_vals_c = transmat_mat[bidx_group_list[0]][:, 0, 1]
+    rn_vals_c = transmat_mat[bidx_group_list[0]][:, 0, 2]
+    wr_vals_c = transmat_mat[bidx_group_list[0]][:, 1, 0]
+    wn_vals_c = transmat_mat[bidx_group_list[0]][:, 1, 2]
+    nr_vals_c = transmat_mat[bidx_group_list[0]][:, 2, 0]
+    nw_vals_c = transmat_mat[bidx_group_list[0]][:, 2, 1]
+
+    # transition from REM may sometime be nan
+    rr_vals_c = rr_vals_c[~np.isnan(rr_vals_c)]
+    rw_vals_c = rw_vals_c[~np.isnan(rw_vals_c)]
+    rn_vals_c = rn_vals_c[~np.isnan(rn_vals_c)]
+
+    if num_groups > 1:
+        # staying
+        # control
+        x_pos = 0 - w + w*w_sf/2 # w*w_sf/2 is just for aligning the bar center
+        ax1.bar(x_pos,
+                height=np.mean(rr_vals_c),
+                yerr=np.std(rr_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos, rr_vals_c)
+        x_pos = 2 - w + w*w_sf/2
+        ax1.bar(x_pos,
+                height=np.mean(nn_vals_c),
+                yerr=np.std(nn_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos, nn_vals_c)
+        x_pos = 4 - w + w*w_sf/2 
+        ax1.bar(x_pos,
+                height=np.mean(ww_vals_c),
+                yerr=np.std(ww_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos, ww_vals_c)
+
+        # tests.
+        for g_idx in range(1, num_groups):
+            num_t = np.sum(bidx_group_list[g_idx])
+            rr_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 0, 0]
+            ww_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 1, 1]
+            nn_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 2, 2]
+            x_pos = 0 + w*w_sf/2 - w + g_idx*w*w_sf
+
+            ax1.bar(x_pos,
+                    height=np.mean(rr_vals_t),
+                    yerr=np.std(rr_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+            scatter_datapoints(ax1, w, x_pos, rr_vals_t)
+            x_pos = 2 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax1.bar(x_pos,
+                    height=np.mean(nn_vals_t),
+                    yerr=np.std(nn_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+            scatter_datapoints(ax1, w, x_pos, nn_vals_t)
+            x_pos = 4 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax1.bar(x_pos,
+                    height=np.mean(ww_vals_t),
+                    yerr=np.std(ww_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+            scatter_datapoints(ax1, w, x_pos, ww_vals_t)
+
+        # Trnsitions from REM
+        # control
+        x_pos = 0 - w + w*w_sf/2
+        ax2.bar(x_pos,
+                height=np.mean(rn_vals_c),
+                yerr=np.std(rn_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax2, w, x_pos, rn_vals_c)
+        x_pos = 2 - w + w*w_sf/2
+        ax2.bar(x_pos,
+                height=np.mean(rw_vals_c),
+                yerr=np.std(rw_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax2, w, x_pos, rw_vals_c)
+
+        # tests.
+        for g_idx in range(1, num_groups):
+            num_t = np.sum(bidx_group_list[g_idx])
+            rw_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 0, 1]
+            rn_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 0, 2]
+            x_pos = 0 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax2.bar(x_pos,
+                    height=np.mean(rn_vals_t),
+                    yerr=np.std(rn_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+            scatter_datapoints(ax2, w, x_pos, rn_vals_t)
+            x_pos = 2 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax2.bar(x_pos,
+                    height=np.mean(rw_vals_t),
+                    yerr=np.std(rw_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+            scatter_datapoints(ax2, w, x_pos, rw_vals_t)
+
+        # Trnsitions from NREM
+        # control
+        x_pos = 0 - w + w*w_sf/2
+        ax3.bar(x_pos,
+                height=np.mean(nr_vals_c),
+                yerr=np.std(nr_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax3, w, x_pos, nr_vals_c)
+        x_pos = 2 - w + w*w_sf/2
+        ax3.bar(x_pos,
+                height=np.mean(nw_vals_c),
+                yerr=np.std(nw_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax3, w, x_pos, nw_vals_c)
+
+        # tests.
+        for g_idx in range(1, num_groups):
+            num_t = np.sum(bidx_group_list[g_idx])
+            nr_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 2, 0]
+            nw_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 2, 1]
+            x_pos = 0 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax3.bar(x_pos,
+                    height=np.mean(nr_vals_t),
+                    yerr=np.std(nr_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+            scatter_datapoints(ax3, w, x_pos, nr_vals_t)
+            x_pos = 2 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax3.bar(x_pos,
+                    height=np.mean(nw_vals_t),
+                    yerr=np.std(nw_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+            scatter_datapoints(ax3, w, x_pos, nw_vals_t)
+
+        # Trnsitions from Wake
+        # control
+        x_pos = 0 - w + w*w_sf/2
+        ax4.bar(x_pos,
+                height=np.mean(wr_vals_c),
+                yerr=np.std(wr_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax4, w, x_pos, wr_vals_c)
+        x_pos = 2 - w + w*w_sf/2
+        ax4.bar(x_pos,
+                height=np.mean(wn_vals_c),
+                yerr=np.std(wn_vals_c)/num_c,
+                align='center', width=w*w_sf*0.9, capsize=6, color='grey', alpha=0.6)
+        scatter_datapoints(ax4, w, x_pos, wn_vals_c)
+
+        # tests.
+        for g_idx in range(1, num_groups):
+            num_t = np.sum(bidx_group_list[g_idx])
+            wr_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 1, 0]
+            wn_vals_t = transmat_mat[bidx_group_list[g_idx]][:, 1, 2]
+            x_pos = 0 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax4.bar(x_pos,
+                    height=np.mean(wr_vals_t),
+                    yerr=np.std(wr_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+            scatter_datapoints(ax4, w, x_pos, wr_vals_t)
+            x_pos = 2 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax4.bar(x_pos,
+                    height=np.mean(wn_vals_t),
+                    yerr=np.std(wn_vals_t)/num_t,
+                    align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+            scatter_datapoints(ax4, w, x_pos, wn_vals_t)
+    else:
+        # staying
+        # single group
+        x_pos = 0 - w/2
+        ax1.bar(x_pos,
+                height=np.mean(rr_vals_c),
+                yerr=np.std(rr_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos, rr_vals_c)
+        x_pos = 2 - w/2
+        ax1.bar(x_pos,
+                height=np.mean(nn_vals_c),
+                yerr=np.std(nn_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos, nn_vals_c)
+        x_pos = 4 - w/2
+        ax1.bar(x_pos,
+                height=np.mean(ww_vals_c),
+                yerr=np.std(ww_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+        scatter_datapoints(ax1, w, x_pos, ww_vals_c)
+        # Trnsitions from REM
+        # single group
+        x_pos = 0 - w/2
+        ax2.bar(x_pos,
+                height=np.mean(rn_vals_c),
+                yerr=np.std(rn_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+        scatter_datapoints(ax2, w, x_pos, rn_vals_c)
+        x_pos = 2 - w/2
+        ax2.bar(x_pos,
+                height=np.mean(rw_vals_c),
+                yerr=np.std(rw_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_REM, alpha=0.6)
+        scatter_datapoints(ax2, w, x_pos, rw_vals_c)
+        # Trnsitions from NREM
+        # single group
+        x_pos = 0 - w/2
+        ax3.bar(x_pos,
+                height=np.mean(nr_vals_c),
+                yerr=np.std(nr_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+        scatter_datapoints(ax3, w, x_pos, nr_vals_c)
+        x_pos = 2 - w/2
+        ax3.bar(x_pos,
+                height=np.mean(nw_vals_c),
+                yerr=np.std(nw_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+        scatter_datapoints(ax3, w, x_pos, nw_vals_c)
+        # Trnsitions from Wake
+        # single group
+        x_pos = 0 - w/2
+        ax4.bar(x_pos,
+                height=np.mean(wr_vals_c),
+                yerr=np.std(wr_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+        scatter_datapoints(ax4, w, x_pos, wr_vals_c)
+        x_pos = 2 - w/2
+        ax4.bar(x_pos,
+                height=np.mean(wn_vals_c),
+                yerr=np.std(wn_vals_c)/num_c,
+                align='center', width=w, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+        scatter_datapoints(ax4, w, x_pos, wn_vals_c)
+
+    return(fig)
+
+
+def draw_transition_barchart_prob(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    transmat_mat = np.array(stagetime_stats['transmat'])
+
+    fig = _draw_transition_barchart(mouse_groups, transmat_mat)
+    axes = fig.axes
+    axes[0].set_ylabel('prob. to stay')
+    axes[1].set_ylabel('prob. to transit from REM')
+    axes[2].set_ylabel('prob. to transit from NREM')
+    axes[3].set_ylabel('prob. to transit from Wake')
+    fig.suptitle('transition probability')
+    filename = f'stage-transition_probability_barchart_{"_".join(mouse_groups_set)}'
+    sc.savefig(output_dir, filename, fig)
+
+
+def _odd(p, epoch_num):
+    min_p = 1/epoch_num  # zero probability is replaced by this value
+    max_p = 1-1/epoch_num
+    pp = min(max(p, min_p), max_p)
+    return np.log10(pp/(1-pp))
+
+
+def draw_transition_barchart_logodds(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    transmat_mat = np.array(stagetime_stats['transmat'])
+    transmat_mat = np.vectorize(_odd)(transmat_mat, epoch_num)
+
+    fig = _draw_transition_barchart(mouse_groups, transmat_mat)
+    axes = fig.axes
+    axes[0].set_ylabel('log odds to stay')
+    axes[1].set_ylabel('log odds to transit from REM')
+    axes[2].set_ylabel('log odds to transit from NREM')
+    axes[3].set_ylabel('log odds to transit from Wake')
+    fig.suptitle('transition probability (log odds)')
+    filename = f'stage-transition_probability_barchart_logodds_{"_".join(mouse_groups_set)}'
+    sc.savefig(output_dir, filename, fig)
+
+
+def _draw_swtransition_barchart(mouse_groups, swtrans_mat):
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+    num_groups = len(mouse_groups_set)
+
+    fig = Figure(figsize=(4, 4))
+    ax = fig.add_subplot(111)
+
+    w = 0.8  # bar width
+    w_sf = 2 / num_groups # scale factor for the bar width
+    ax.set_xticks([0, 2])
+    ax.set_xticklabels(['Psw', 'Pws'])
+
+    if num_groups > 1:
+        # control group (always index: 0)
+        num_c = np.sum(bidx_group_list[0])
+        sw_vals_c = swtrans_mat[bidx_group_list[0]][:, 0]
+        ws_vals_c = swtrans_mat[bidx_group_list[0]][:, 1]
+
+        ## Psw and Pws
+        x_pos = 0 - w + w*w_sf/2 # w*w_sf/2 is just for aligning the bar center
+        ax.bar(x_pos,
+            height=np.mean(sw_vals_c),
+            yerr=np.std(sw_vals_c)/num_c,
+            align='center', width=w*w_sf*0.9, capsize=6, color='gray', alpha=0.6)
+        scatter_datapoints(ax, w, x_pos, sw_vals_c)
+        x_pos = 2 - w + w*w_sf/2 # w*w_sf/2 is just for aligning the bar center
+        ax.bar(x_pos,
+            height=np.mean(ws_vals_c),
+            yerr=np.std(ws_vals_c)/num_c,
+            align='center', width=w*w_sf*0.9, capsize=6, color='gray', alpha=0.6)
+        scatter_datapoints(ax, w, x_pos, ws_vals_c)
+
+        # test group index: g_idx.
+        for g_idx in range(1, num_groups):
+            num_t = np.sum(bidx_group_list[g_idx])
+            sw_vals_t = swtrans_mat[bidx_group_list[g_idx]][:, 0]
+            x_pos = 0 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax.bar(x_pos,
+                height=np.mean(sw_vals_t),
+                yerr=np.std(sw_vals_t)/num_t,
+                align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+            scatter_datapoints(ax, w, x_pos, sw_vals_t)
+
+            ws_vals_t = swtrans_mat[bidx_group_list[g_idx]][:, 1]
+            x_pos = 2 + w*w_sf/2 - w + g_idx*w*w_sf
+            ax.bar(x_pos,
+                height=np.mean(ws_vals_t),
+                yerr=np.std(ws_vals_t)/num_t,
+                align='center', width=w*w_sf*0.9, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+            scatter_datapoints(ax, w, x_pos, ws_vals_t)
+    else:
+        # single group
+        g_idx = 0
+        num = np.sum(bidx_group_list[g_idx])
+        sw_vals = swtrans_mat[bidx_group_list[g_idx]][:, 0]
+        x_pos = 0 + g_idx*w/2
+        ax.bar(x_pos,
+            height=np.mean(sw_vals),
+            yerr=np.std(sw_vals)/num,
+            align='center', width=w, capsize=6, color=stage.COLOR_NREM, alpha=0.6)
+        scatter_datapoints(ax, w, x_pos, sw_vals)
+
+        ws_vals = swtrans_mat[bidx_group_list[g_idx]][:, 1]
+        x_pos = 2 + g_idx*w/2
+        ax.bar(x_pos,
+            height=np.mean(ws_vals),
+            yerr=np.std(ws_vals)/num,
+            align='center', width=w, capsize=6, color=stage.COLOR_WAKE, alpha=0.6)
+        scatter_datapoints(ax, w, x_pos, ws_vals)
+
+    return(fig)
+
+
+def draw_swtransition_barchart_prob(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    swtrans_mat = np.array(stagetime_stats['swtrans'])
+
+    fig = _draw_swtransition_barchart(mouse_groups, swtrans_mat)
+    axes = fig.axes
+    axes[0].set_ylabel('prob. to transit\n between sleep and wake')
+    fig.suptitle('sleep/wake trantision probability')
+    filename = f'sleep-wake-transition_probability_barchart_{"_".join(mouse_groups_set)}'
+    sc.savefig(output_dir, filename, fig)
+
+
+def draw_swtransition_barchart_logodds(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    epoch_num = stagetime_stats['epoch_num_in_range']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+    swtrans_mat = np.array(stagetime_stats['swtrans'])
+    swtrans_mat = np.vectorize(_odd)(swtrans_mat, epoch_num)
+
+    fig = _draw_swtransition_barchart(mouse_groups, swtrans_mat)
+    axes = fig.axes
+    axes[0].set_ylabel('log odds to transit\n between sleep and wake')
+    fig.suptitle('sleep/wake trantision probability (log odds)')
+    filename = f'sleep-wake-transition_probability_barchart_logodds_{"_".join(mouse_groups_set)}'
+    sc.savefig(output_dir, filename, fig)
+
+
+def log_psd_inv(y, normalizing_fac, normalizing_mean):
+    """ inverses the spectrum normalized PSD to get the original PSD. 
+    The spectrum normalization is defined as: snorm(log(psd)),
+    where log() here means a "decibel like" transformation of 10*np.log10(),
+    and snorm() means a standerdization (i.e. mean=0, SD=0) of each frequency
+    component of log(PSD). This function implements log^-1(snorm^-1()).
+
+    Arguments:
+        y {np.array(freq_bins)} -- spectrum normalized PSD
+        normalizing_fac {float} -- SD of each frequency component used for the normalization
+        normalizing_mean {float} -- mean of each frequency compenent used for the normalization
+
+    Returns:
+        [np_array(freq_bins)] -- original PSD
+    """
+
+    return 10**((y / normalizing_fac + normalizing_mean) / 10)
+
+
+def conv_PSD_from_snorm_PSD(spec_norm):
+    """ calculates the conventional PSD from the spectrum normalized PSD matrix.
+    The shape of the input PSD matrix is (epoch_num, freq_bins). 
+
+    Arguments:
+        spec_norm {'psd': a matrix of spectrum normalized PSD,
+                   'norm_fac: an array of factors used to normalize the PSD
+                   'mean': an array of means used to normalize the PSD} -- a dict of 
+                   spectrum normalized PSD and the associated factors and means.
+
+    Returns:
+        [np.array(epoch_num, freq_bins)] -- a conventional PSD matrix
+    """
+
+    psd_norm_mat = spec_norm['psd']
+    nf = spec_norm['norm_fac']
+    nm = spec_norm['mean']
+    psd_mat = np.vectorize(log_psd_inv)(psd_norm_mat, nf, nm)
+
+    return psd_mat
+
+
+def write_sleep_stats(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # mouse_group, stage_type, num, mean, SD, pvalue, star, method
+    sleep_stats_df = pd.DataFrame()
+
+    # mouse_group's index:0 is always control
+    mg = mouse_groups_set[0]
+    bidx = bidx_group_list[0]
+    num = np.sum(bidx)
+    rem_values_c = stagetime_df['REM'].values[bidx]
+    nrem_values_c = stagetime_df['NREM'].values[bidx]
+    wake_values_c = stagetime_df['Wake'].values[bidx]
+    row1 = [mg, 'REM',  num, np.mean(rem_values_c),  np.std(
+        rem_values_c),  np.nan, None, None]
+    row2 = [mg, 'NREM', num, np.mean(nrem_values_c), np.std(
+        nrem_values_c), np.nan, None, None]
+    row3 = [mg, 'Wake', num, np.mean(wake_values_c), np.std(
+        wake_values_c), np.nan, None, None]
+
+    #sleep_stats_df = sleep_stats_df.append([row1, row2, row3])
+    sleep_stats_df = pd.concat([sleep_stats_df, pd.DataFrame([row1, row2, row3])], ignore_index=True)
+    for i, bidx in enumerate(bidx_group_list[1:]):
+        idx = i+1
+        mg = mouse_groups_set[idx]
+        bidx = bidx_group_list[idx]
+        num = np.sum(bidx)
+        rem_values_t = stagetime_df['REM'].values[bidx]
+        nrem_values_t = stagetime_df['NREM'].values[bidx]
+        wake_values_t = stagetime_df['Wake'].values[bidx]
+
+        tr = sc.test_two_sample(rem_values_c,  rem_values_t)  # test for REM
+        tn = sc.test_two_sample(nrem_values_c, nrem_values_t)  # test for NREM
+        tw = sc.test_two_sample(wake_values_c, wake_values_t)  # test for Wake
+        row1 = [mg, 'REM',  num, np.mean(rem_values_t),  np.std(
+            rem_values_t),  tr['p_value'], tr['stars'], tr['method']]
+        row2 = [mg, 'NREM', num, np.mean(nrem_values_t), np.std(
+            nrem_values_t), tn['p_value'], tn['stars'], tn['method']]
+        row3 = [mg, 'Wake', num, np.mean(wake_values_t), np.std(
+            wake_values_t), tw['p_value'], tw['stars'], tw['method']]
+
+        #sleep_stats_df = sleep_stats_df.append([row1, row2, row3])
+        sleep_stats_df = pd.concat([sleep_stats_df, pd.DataFrame([row1, row2, row3])], ignore_index=True)
+
+    sleep_stats_df.columns = ['Mouse group', 'Stage type',
+                              'N', 'Mean', 'SD', 'Pvalue', 'Stars', 'Method']
+
+    stagetime_df = stagetime_df.round(
+        {'REM': 2, 'NREM': 2, 'Wake': 2, 'Unknown': 2})
+
+    sleep_stats_df.to_csv(os.path.join(
+        output_dir, 'stage-time_stats_table.csv'), index=False)
+    stagetime_df.to_csv(os.path.join(
+        output_dir, 'stage-time_table.csv'), index=False)
+
+
+def write_stagetrans_stats(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # mouse_group, trans_type, num, mean, SD, pvalue, star, method
+    transmat_mat = np.array(stagetime_stats['transmat'])
+    stagetrans_stats_df = pd.DataFrame()
+
+    # mouse_group's index:0 is always control
+    mg = mouse_groups_set[0]
+    bidx = bidx_group_list[0]
+    num = np.sum(bidx)
+    rr_vals_c = transmat_mat[bidx][:, 0, 0]
+    ww_vals_c = transmat_mat[bidx][:, 1, 1]
+    nn_vals_c = transmat_mat[bidx][:, 2, 2]
+    rw_vals_c = transmat_mat[bidx][:, 0, 1]
+    rn_vals_c = transmat_mat[bidx][:, 0, 2]
+    wr_vals_c = transmat_mat[bidx][:, 1, 0]
+    wn_vals_c = transmat_mat[bidx][:, 1, 2]
+    nr_vals_c = transmat_mat[bidx][:, 2, 0]
+    nw_vals_c = transmat_mat[bidx][:, 2, 1]
+    row1 = [mg, 'RR', num, np.mean(rr_vals_c), np.std(rr_vals_c), np.nan, None, None]
+    row2 = [mg, 'NN', num, np.mean(nn_vals_c), np.std(nn_vals_c), np.nan, None, None]
+    row3 = [mg, 'WW', num, np.mean(ww_vals_c), np.std(ww_vals_c), np.nan, None, None]
+    row4 = [mg, 'RN', num, np.mean(rn_vals_c), np.std(rn_vals_c), np.nan, None, None]
+    row5 = [mg, 'RW', num, np.mean(rw_vals_c), np.std(rw_vals_c), np.nan, None, None]
+    row6 = [mg, 'NR', num, np.mean(nr_vals_c), np.std(nr_vals_c), np.nan, None, None]
+    row7 = [mg, 'NW', num, np.mean(nw_vals_c), np.std(nw_vals_c), np.nan, None, None]
+    row8 = [mg, 'WR', num, np.mean(wr_vals_c), np.std(wr_vals_c), np.nan, None, None]
+    row9 = [mg, 'WN', num, np.mean(wn_vals_c), np.std(wn_vals_c), np.nan, None, None]
+
+
+    #stagetrans_stats_df = stagetrans_stats_df.append([row1, row2, row3, row4, row5, row6, row7, row8, row9])
+    stagetrans_stats_df = pd.concat([stagetrans_stats_df, pd.DataFrame([row1, row2, row3, row4, row5, row6, row7, row8, row9])], 
+                                    ignore_index=True)
+    for i, bidx in enumerate(bidx_group_list[1:]):
+        idx = i+1
+        mg = mouse_groups_set[idx]
+        bidx = bidx_group_list[idx]
+        num = np.sum(bidx)
+        rr_vals_t = transmat_mat[bidx][:, 0, 0]
+        ww_vals_t = transmat_mat[bidx][:, 1, 1]
+        nn_vals_t = transmat_mat[bidx][:, 2, 2]
+        rw_vals_t = transmat_mat[bidx][:, 0, 1]
+        rn_vals_t = transmat_mat[bidx][:, 0, 2]
+        wr_vals_t = transmat_mat[bidx][:, 1, 0]
+        wn_vals_t = transmat_mat[bidx][:, 1, 2]
+        nr_vals_t = transmat_mat[bidx][:, 2, 0]
+        nw_vals_t = transmat_mat[bidx][:, 2, 1]
+
+        trr = sc.test_two_sample(rr_vals_c, rr_vals_t)   
+        tnn = sc.test_two_sample(nn_vals_c, nn_vals_t)  
+        tww = sc.test_two_sample(ww_vals_c, ww_vals_t)  
+        trw = sc.test_two_sample(rw_vals_c, rw_vals_t)  
+        trn = sc.test_two_sample(rn_vals_c, rn_vals_t)  
+        twr = sc.test_two_sample(wr_vals_c, wr_vals_t)  
+        twn = sc.test_two_sample(wn_vals_c, wn_vals_t)  
+        tnr = sc.test_two_sample(nr_vals_c, nr_vals_t)  
+        tnw = sc.test_two_sample(nw_vals_c, nw_vals_t)  
+
+        row1 = [mg, 'RR', num, np.mean(rr_vals_t), np.std(rr_vals_t), trr['p_value'], trr['stars'], trr['method']]
+        row2 = [mg, 'NN', num, np.mean(nn_vals_t), np.std(nn_vals_t), tnn['p_value'], tnn['stars'], tnn['method']]
+        row3 = [mg, 'WW', num, np.mean(ww_vals_t), np.std(ww_vals_t), tww['p_value'], tww['stars'], tww['method']]
+        row4 = [mg, 'RN', num, np.mean(rn_vals_t), np.std(rn_vals_t), trn['p_value'], trn['stars'], trn['method']]
+        row5 = [mg, 'RW', num, np.mean(rw_vals_t), np.std(rw_vals_t), trw['p_value'], trw['stars'], trw['method']]
+        row6 = [mg, 'NR', num, np.mean(nr_vals_t), np.std(nr_vals_t), tnr['p_value'], tnr['stars'], tnr['method']]
+        row7 = [mg, 'NW', num, np.mean(nw_vals_t), np.std(nw_vals_t), tnw['p_value'], tnw['stars'], tnw['method']]
+        row8 = [mg, 'WR', num, np.mean(wr_vals_t), np.std(wr_vals_t), twr['p_value'], twr['stars'], twr['method']]
+        row9 = [mg, 'WN', num, np.mean(wn_vals_t), np.std(wn_vals_t), twn['p_value'], twn['stars'], twn['method']]
+
+        #stagetrans_stats_df = stagetrans_stats_df.append([row1, row2, row3, row4, row5, row6, row7, row8, row9])
+        stagetrans_stats_df = pd.concat([stagetrans_stats_df, pd.DataFrame([row1, row2, row3, row4, row5, row6, row7, row8, row9])], 
+                                    ignore_index=True)
+        
+
+    stagetrans_stats_df.columns = ['Mouse group', 'Trans type',
+                              'N', 'Mean', 'SD', 'Pvalue', 'Stars', 'Method']
+
+    stagetrans_df = pd.DataFrame(transmat_mat.reshape(-1, 9), columns=['Prr', 'Prw', 'Prn', 'Pwr', 'Pww', 'Pwn', 'Pnr', 'Pnw', 'Pnn'])
+    mouse_info_df = stagetime_stats['stagetime'].iloc[:,0:4]
+    stagetrans_df = pd.concat([mouse_info_df, stagetrans_df], axis = 1)
+
+    stagetrans_stats_df.to_csv(os.path.join(
+        output_dir, 'stage-transition_probability_stats_table.csv'), index=False)
+    stagetrans_df.to_csv(os.path.join(
+        output_dir, 'stage-transition_probability_table.csv'), index=False)
+
+
+def write_swtrans_stats(stagetime_stats, output_dir):
+    stagetime_df = stagetime_stats['stagetime']
+    mouse_groups = stagetime_df['Mouse group'].values
+    mouse_groups_set = sorted(set(mouse_groups), key=list(
+        mouse_groups).index)  # unique elements with preseved order
+
+    bidx_group_list = [mouse_groups == g for g in mouse_groups_set]
+
+    # mouse_group, stage_type, num, mean, SD, pvalue, star, method
+    swtrans_stats_df = pd.DataFrame()
+    
+    # mouse_group's index:0 is always control
+    mg = mouse_groups_set[0]
+    bidx = bidx_group_list[0]
+    num = np.sum(bidx)
+    swtrans_mat = np.array(stagetime_stats['swtrans'])
+    psw_values_c = swtrans_mat[bidx, 0]
+    pws_values_c = swtrans_mat[bidx, 1]
+ 
+    row1 = [mg, 'Psw',  num, np.mean(psw_values_c),  np.std(
+        psw_values_c),  np.nan, None, None]
+    row2 = [mg, 'Pws', num, np.mean(pws_values_c), np.std(
+        pws_values_c), np.nan, None, None]
+
+    #swtrans_stats_df = swtrans_stats_df.append([row1, row2])
+    swtrans_stats_df = pd.concat([swtrans_stats_df, pd.DataFrame([row1, row2])], 
+                                    ignore_index=True)
+    for i, bidx in enumerate(bidx_group_list[1:]):
+        idx = i+1
+        mg = mouse_groups_set[idx]
+        bidx = bidx_group_list[idx]
+        num = np.sum(bidx)
+        psw_values_t = swtrans_mat[bidx, 0]
+        pws_values_t = swtrans_mat[bidx, 1]
+
+        t_psw = sc.test_two_sample(psw_values_c,  psw_values_t)  # test for Psw
+        t_pws = sc.test_two_sample(pws_values_c,  pws_values_t)  # test for Pws
+        row1 = [mg, 'Psw',  num, np.mean(psw_values_t),  np.std(
+            psw_values_t),  t_psw['p_value'], t_psw['stars'], t_psw['method']]
+        row2 = [mg, 'Pws', num, np.mean(pws_values_t), np.std(
+            pws_values_t), t_pws['p_value'], t_pws['stars'], t_pws['method']]
+
+        #swtrans_stats_df = swtrans_stats_df.append([row1, row2])
+        swtrans_stats_df = pd.concat([swtrans_stats_df, pd.DataFrame([row1, row2])], 
+                                    ignore_index=True)
+
+    swtrans_stats_df.columns = ['Mouse group', 'trans type',
+                              'N', 'Mean', 'SD', 'Pvalue', 'Stars', 'Method']
+
+    swtrans_df = pd.DataFrame(swtrans_mat, columns=['Psw', 'Pws'])
+    mouse_info_df = stagetime_stats['stagetime'].iloc[:,0:4]
+    swtrans_df = pd.concat([mouse_info_df, swtrans_df], axis = 1)
+
+    swtrans_stats_df.to_csv(os.path.join(
+        output_dir, 'sleep-wake-transition_probability_stats_table.csv'), index=False)
+    swtrans_df.to_csv(os.path.join(
+        output_dir, 'sleep-wake-transition_probability_table.csv'), index=False)
+
+
+def pickle_psd_info_list(psd_info_list, output_dir, filename):
+    """ Save the psd_info_list into a file
+
+    Args:
+        psd_info_list (list of dict): An object made by make_target_psd_info()
+        output_dir: The path to the folder of summary files
+        filename (str): The filename of the pickle file
+    
+    Note: This function assumes the PSD folder already exists
+    """
+    # Save the psd_info_lists
+    pkl_path = os.path.join(output_dir, filename)
+    with open(pkl_path, 'wb') as pkl:
+        pickle.dump(psd_info_list, pkl)
+
+
+def process_psd_profile(psd_info_list, log_psd_info_list, percentage_psd_info_list, epoch_len_sec, sample_freq, output_dir, psd_type, vol_unit='V'):
+    # Mask for the fist halfday
+    epoch_num_halfday = int(12*60*60/epoch_len_sec)
+    #mask_first_halfday = np.tile(
+    #    np.hstack([np.full(epoch_num_halfday, True), 
+    #    np.full(epoch_num_halfday, False)]), 
+    #    day_num)
+    # make mask
+    psd_info=psd_info_list[0]
+    mask = np.full(len(psd_info['bidx_target']), False)
+
+
+    # PSD profiles (all day)
+    psd_profiles_df ,hourly_psd_profiles_df= sp.make_psd_profile(psd_info_list, sample_freq,
+                                                                 epoch_len_sec, psd_type,hourly=True)
+    log_psd_profiles_df, hourly_log_psd_profiles_df = sp.make_psd_profile(log_psd_info_list, sample_freq,
+                                                                          epoch_len_sec, psd_type,hourly=True)
+    percentage_psd_profiles_df, hourly_percentage_psd_profiles_df = sp.make_psd_profile(
+        percentage_psd_info_list, sample_freq,epoch_len_sec, psd_type,hourly=True)
+
+    psd_output_dir = os.path.join(output_dir, f'PSD_{psd_type}')
+
+    # write a table of PSD (all day)
+    sp.write_psd_stats(psd_profiles_df, psd_output_dir, f'{psd_type}_allday_')
+    sp.write_psd_stats(log_psd_profiles_df, psd_output_dir, f'{psd_type}_allday_log-')
+    sp.write_psd_stats(percentage_psd_profiles_df, psd_output_dir, f'{psd_type}_allday_percentage-', np.sum)
+    
+    # write a table of PSD (hourly)
+    opt_label=f'{psd_type}_hourly_allday_'
+    hourly_psd_profiles_df.to_csv(os.path.join(
+        psd_output_dir, f'PSD_{opt_label}profile.csv'), index=False)
+    opt_label=f'{psd_type}_hourly_allday_log-'
+    hourly_log_psd_profiles_df.to_csv(os.path.join(
+        psd_output_dir, f'PSD_{opt_label}profile.csv'), index=False)
+    opt_label=f'{psd_type}_hourly_allday_percentage-'
+    hourly_percentage_psd_profiles_df.to_csv(os.path.join(
+        psd_output_dir, f'PSD_{opt_label}profile.csv'), index=False)
+    #sp.write_psd_stats(hourly_psd_profiles_df, psd_output_dir, f'{psd_type}_hourly_allday_')
+    #sp.write_psd_stats(hourly_log_psd_profiles_df, psd_output_dir, f'{psd_type}_hourly_allday_log-')
+    #sp.write_psd_stats(hourly_percentage_psd_profiles_df, psd_output_dir, f'{psd_type}_hourly_allday_percentage-', np.sum)
+
+    # draw PSDs (all day)
+    print_log(f'Drawing the PSDs (type:{psd_type})')
+    if psd_type == 'norm':
+        unit = 'AU'
+    elif psd_type == 'raw':
+        unit = f'${vol_unit}^{2}/Hz$'
+    else:
+        unit = 'Unknown'
+    sp.draw_PSDs_individual(psd_profiles_df, sample_freq,
+                         f'{psd_type} PSD [{unit}]', psd_output_dir, f'{psd_type}_allday_')
+    sp.draw_PSDs_individual(log_psd_profiles_df, sample_freq,
+                         f'{psd_type} PSD [log {unit}]', psd_output_dir, f'{psd_type}_allday_log-')
+    sp.draw_PSDs_individual(percentage_psd_profiles_df, sample_freq,
+                         f'{psd_type} percentage PSD [%]', psd_output_dir, f'{psd_type}_allday_percentage-')
+
+    sp.draw_PSDs_group(psd_profiles_df, sample_freq,
+                    f'{psd_type} PSD [{unit}]', psd_output_dir, f'{psd_type}_allday_')
+    sp.draw_PSDs_group(log_psd_profiles_df, sample_freq,
+                    f'{psd_type} PSD [log {unit}]', psd_output_dir, f'{psd_type}_allday_log-')
+    sp.draw_PSDs_group(percentage_psd_profiles_df, sample_freq,
+                    f'{psd_type} percentage PSD [%]', psd_output_dir, f'{psd_type}_allday_percentage-')
+
+def process_psd_timeseries(psd_info_list, percentage_psd_info_list, epoch_range, epoch_len_sec, sample_freq, output_dir, psd_type, vol_unit='V'):
+    freq_bins = sp.psd_freq_bins(sample_freq)
+    bidx_delta_freq = (freq_bins<4) # 11 bins
+    bidx_all_freq = np.full(129, True)
+
+    print_log(f'Making the delta-power timeseries in all stages (type:{psd_type})')
+    psd_delta_timeseries_df = sp.make_psd_timeseries_df(psd_info_list, epoch_range,  bidx_delta_freq, None, psd_type)
+    print_log(f'Making the delta-power timeseries in NREM (type:{psd_type})')
+    psd_delta_timeseries_nrem_df = sp.make_psd_timeseries_df(psd_info_list, epoch_range,  bidx_delta_freq, 'bidx_nrem', psd_type)
+    print_log(f'Making the delta-power timeseries in all stages (percentage) (type:{psd_type})')
+    percentage_psd_delta_timeseries_df = sp.make_psd_timeseries_df(percentage_psd_info_list, epoch_range,  bidx_delta_freq, None, psd_type)
+    print_log(f'Making the delta-power timeseries in NREM (percentage) (type:{psd_type})')
+    percentage_psd_delta_timeseries_nrem_df = sp.make_psd_timeseries_df(percentage_psd_info_list, epoch_range,  bidx_delta_freq, 'bidx_nrem', psd_type)
+    print_log(f'Making the total-power timeseries in Wake (type:{psd_type})')
+    psd_total_timeseries_wake_df = sp.make_psd_timeseries_df(psd_info_list, epoch_range,  bidx_all_freq, 'bidx_wake', psd_type)
+    print_log(f'Making the delta-power timeseries in Wake (type:{psd_type})')
+    psd_delta_timeseries_wake_df = sp.make_psd_timeseries_df(psd_info_list, epoch_range,  bidx_delta_freq, 'bidx_wake', psd_type)
+    print_log(f'Making the delta-power timeseries in Wake (percentage) (type:{psd_type})')
+    percentage_psd_delta_timeseries_wake_df = sp.make_psd_timeseries_df(percentage_psd_info_list, epoch_range, bidx_delta_freq, 'bidx_wake', psd_type)
+
+
+    # draw delta-power timeseries
+    print_log(f'Drawing the power timeseries (type:{psd_type})')
+    psd_output_dir = os.path.join(output_dir, f'PSD_{psd_type}')
+    if psd_type == 'norm':
+        unit = 'AU'
+    elif psd_type == 'raw':
+        unit = f'${vol_unit}^{2}/Hz$'
+    else:
+        unit = 'Unknown'
+    # delta in all epoch
+    psd_delta_timeseries_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_delta.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(psd_delta_timeseries_df, epoch_len_sec, f'Hourly delta power [{unit}]', psd_output_dir, f'{psd_type}_delta')
+    sp.draw_psd_domain_power_timeseries_grouped(psd_delta_timeseries_df, epoch_len_sec, f'Hourly delta power [{unit}]', psd_output_dir, f'{psd_type}_delta')
+    # delta percentage in all epoch
+    percentage_psd_delta_timeseries_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_delta_percentage.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(percentage_psd_delta_timeseries_df, epoch_len_sec, 'Hourly delta power [%]', psd_output_dir, f'{psd_type}_delta_percentage')
+    sp.draw_psd_domain_power_timeseries_grouped(percentage_psd_delta_timeseries_df, epoch_len_sec, 'Hourly delta power [%]', psd_output_dir, f'{psd_type}_delta_percentage')
+    # delta in NREM 
+    psd_delta_timeseries_nrem_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_delta_NREM.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(psd_delta_timeseries_nrem_df, epoch_len_sec, f'Hourly NREM delta power [{unit}]', psd_output_dir, f'{psd_type}_delta', 'NREM_')
+    sp.draw_psd_domain_power_timeseries_grouped(psd_delta_timeseries_nrem_df, epoch_len_sec, f'Hourly NREM delta power [{unit}]', psd_output_dir, f'{psd_type}_delta', 'NREM_')
+    # delta percentage in NREM
+    percentage_psd_delta_timeseries_nrem_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_delta_percentage_NREM.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(percentage_psd_delta_timeseries_nrem_df, epoch_len_sec, 'Hourly NREM delta power [%]', psd_output_dir, f'{psd_type}_delta_percentage', 'NREM_')
+    sp.draw_psd_domain_power_timeseries_grouped(percentage_psd_delta_timeseries_nrem_df, epoch_len_sec, 'Hourly NREM delta power [%]', psd_output_dir, f'{psd_type}_delta_percentage', 'NREM_')
+    # total in Wake
+    psd_total_timeseries_wake_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_total_Wake.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(psd_total_timeseries_wake_df, epoch_len_sec, f'Hourly Wake total power [{unit}]', psd_output_dir, f'{psd_type}_total', 'Wake_')
+    sp.draw_psd_domain_power_timeseries_grouped(psd_total_timeseries_wake_df, epoch_len_sec, f'Hourly Wake total power [{unit}]', psd_output_dir, f'{psd_type}_total', 'Wake_')
+    # delta in Wake
+    psd_delta_timeseries_wake_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_delta_Wake.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(psd_delta_timeseries_wake_df, epoch_len_sec, f'Hourly Wake delta power [{unit}]', psd_output_dir, f'{psd_type}_delta', 'Wake_')
+    sp.draw_psd_domain_power_timeseries_grouped(psd_delta_timeseries_wake_df, epoch_len_sec, f'Hourly Wake delta power [{unit}]', psd_output_dir, f'{psd_type}_delta', 'Wake_')
+    # delta percentage in Wake
+    percentage_psd_delta_timeseries_wake_df.T.to_csv(os.path.join(psd_output_dir, f'power-timeseries_{psd_type}_delta_percentage_Wake.csv'), header=False)
+    sp.draw_psd_domain_power_timeseries_individual(percentage_psd_delta_timeseries_wake_df, epoch_len_sec, 'Hourly Wake delta power [%]', psd_output_dir, f'{psd_type}_delta_percentage', 'Wake_')
+    sp.draw_psd_domain_power_timeseries_grouped(percentage_psd_delta_timeseries_wake_df, epoch_len_sec, 'Hourly Wake delta power [%]', psd_output_dir, f'{psd_type}_delta_percentage', 'Wake_')
+
+def make_psd_output_dirs(output_dir, psd_type):
+    output_dir = os.path.join(output_dir, f'PSD_{psd_type}')
+    os.makedirs(os.path.join(output_dir, 'pdf'), exist_ok=True)
+    
+def extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range):
+    print("extract_EEG_n_EMG")
+    EEG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EEG.pkl"))
+    EMG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EMG.pkl"))
+    EEG_selected=EEG_raw[epoch_range]
+    EMG_selected=EMG_raw[epoch_range]
+    return EEG_selected,EMG_selected
+    
+def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_circadian,result_dir_name="result"):
+    """ make summary statics of each mouse:
+            stagetime in a day: how many minuites of stages each mouse spent in a day
+            stage time profile: hourly profiles of stages over the recording
+            stage circadian profile: hourly profiles of stages over a day
+            transition matrix: transition probability matrix among each stage
+            sw transitino: Sleep (NREM+REM) and Wake transition probability
+
+    Arguments:
+        mouse_info_df {pd.DataFram} -- a dataframe returned by collect_mouse_info_df()
+        epoch_range {slice} -- target eopchs to be summarized
+        epoch_len_sec {int} -- epoch length in seconds
+        stage_ext {str} -- the sub-extention of stage files
+
+    Returns:
+        {'stagetime': pd.DataFrame,
+        'stagetime_profile': [np.array(2)],
+        'stagetime_circadian': [np.array(3)],
+        'transmat': [np.array(3)],
+        'swtrans': [np.array(2)],
+        'swtrans_profile': [[np.array(1), np.array(1)]],
+        'epoch_num': int} -- A dict of dataframe and arrays of summary stats
+    """
+    stagetime_df = pd.DataFrame()
+    stagetime_profile_df = pd.DataFrame()
+    stagetime_profile_list = []
+    bout_table_list=[]
+    bout_profile_list=[]
+    stagetime_circadian_profile_list = []
+    transmat_list = []
+    swtrans_list = []
+    swtrans_profile_list = []
+    swtrans_circadian_profile_list = []
+    EEG_raw_list=[]
+    EMG_raw_list=[]
+    stage_call_list=[]
+
+    for i, r in mouse_info_df.iterrows():
+        device_label = r['Device label'].strip()
+        mouse_group = r['Mouse group'].strip()
+        mouse_id = r['Mouse ID'].strip()
+        stats_report = r['Stats report'].strip().upper()
+        note = r['Note']
+        exp_label = r['Experiment label'].strip()
+        faster_dir = r['FASTER_DIR']
+        if stats_report == 'NO':
+            print_log(f'[{i+1}] Skipping stage: {faster_dir} {device_label}')
+            continue
+
+        # read a stage file
+        print_log(f'[{i+1}] Reading stage: {faster_dir} {device_label} {stage_ext}')
+        stage_call = et.read_stages(os.path.join(
+            faster_dir, result_dir_name), device_label, stage_ext)
+        print(len(stage_call))
+        stage_call = stage_call[epoch_range]
+        epoch_num_in_range = len(stage_call)
+        print(len(stage_call))
+        
+        #extract_raw_EEG_n_EMG
+        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range)
+        EEG_raw_list.append(eeg)
+        EMG_raw_list.append(emg)
+
+        # stagetime in a day
+        rem, nrem, wake, unknown = stagetime_in_a_day(stage_call)
+        #stagetime_df = stagetime_df.append(
+        #    [[exp_label, mouse_group, mouse_id, device_label,
+        #     rem, nrem, wake, unknown, stats_report, note]], ignore_index=True)
+        new_row = pd.DataFrame(
+            [[exp_label, mouse_group, mouse_id, device_label,
+            rem, nrem, wake, unknown, stats_report, note]],
+            columns=['exp_label', 'mouse_group', 'mouse_id', 'device_label',
+                    'rem', 'nrem', 'wake', 'unknown', 'stats_report', 'note']
+        )
+
+        stagetime_df = pd.concat([stagetime_df, new_row], ignore_index=True)
+        
+
+
+        # stagetime profile
+        stagetime_profile_list.append(stagetime_profile(stage_call, epoch_len_sec))
+
+        # bout table 
+        stage_call=np.array(stage_call)
+        bout_df=bout_table(stage_call)
+        bout_table_list.append(bout_df)
+        
+        # bout profile
+        bout_profile_list.append(hourly_bout_profile(bout_df, epoch_len_sec))
+
+        # stage circadian profile
+        if is_circadian:
+            stagetime_circadian_profile_list.append(
+                stagetime_circadian_profile(stage_call, epoch_len_sec))
+
+        # transition matrix
+        transmat_list.append(transmat_from_stages(stage_call))
+
+        # sw transition
+        swtrans_list.append(swtrans_from_stages(stage_call))
+
+        # sw transition profile
+        swtrans_profile_list.append(swtrans_profile(stage_call, epoch_len_sec))
+
+        # sw transition profile
+        if is_circadian:
+            swtrans_circadian_profile_list.append(swtrans_circadian_profile(stage_call, epoch_len_sec))
+            
+        stage_call_list.append(stage_call)
+
+    stagetime_df.columns = ['Experiment label', 'Mouse group', 'Mouse ID',
+                            'Device label', 'REM', 'NREM', 'Wake', 'Unknown',
+                            'Stats report', 'Note']
+
+    return({'stagetime': stagetime_df,
+            'stagetime_profile': stagetime_profile_list,
+            'bout_table':bout_table_list,
+            'bout_profile':bout_profile_list,
+            'stagetime_circadian': stagetime_circadian_profile_list,
+            'transmat': transmat_list,
+            'swtrans': swtrans_list,
+            'swtrans_profile': swtrans_profile_list,
+            'swtrans_circadian': swtrans_circadian_profile_list,
+            'epoch_num_in_range': epoch_num_in_range,
+            'eeg':EEG_raw_list,
+            'emg':EMG_raw_list,
+            'stage_call':stage_call_list})
+
+def do_analysis(faster_dir_list,output_dir,stage_ext,vol_unit,epoch_range,epoch_len_sec,is_circadian,result_dir_name):
+    # collect mouse_infos of the specified (multiple) FASTER dirs
+    mouse_info_collected = collect_mouse_info_df(faster_dir_list, epoch_len_sec)
+    mouse_info_df = mouse_info_collected['mouse_info']
+    sample_freq = mouse_info_collected['sample_freq']
+    start_datetime = mouse_info_collected['start_datetime']
+    epoch_num_in_range=epoch_range.stop-epoch_range.start
+    #epoch_num=epoch_num_in_range
+
+    if stage_ext == None:
+        # default: 'faster2' for *.faster2.csv
+        stage_ext = 'faster2'
+
+    # set the output directory
+    if output_dir == None:
+        # default: output to the first FASTER2 directory
+        if len(faster_dir_list) > 1:
+            basenames = [os.path.basename(dir_path)
+                            for dir_path in faster_dir_list]
+            path_ext = '_' + '_'.join(basenames)
+        else:
+            path_ext = ''
+        output_dir = os.path.join(os.getcwd(), 'summary' + path_ext)
+    os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(os.path.join(output_dir, 'pdf'), exist_ok=True)
+    os.makedirs(os.path.join(output_dir, 'log'), exist_ok=True)
+
+    # prepare stagetime statistics
+    stagetime_stats = make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_circadian,result_dir_name)
+    #stagetime_stats.to_csv(os.path.join(output_dir, 'stagetime_stats.csv'))
+    #stagetime_stats.to_pickle(os.path.join(output_dir, 'stagetime_stats.pickle'))
+    np.save(os.path.join(output_dir, 'stagetime_stats.npy'),stagetime_stats)
+
+    # write tables of sleeptime stats 
+    write_sleep_stats(stagetime_stats, output_dir)
+
+    # write tables of sleep-wake transition stats
+    write_swtrans_stats(stagetime_stats, output_dir)
+
+    # write tables of stage transition stats
+    write_stagetrans_stats(stagetime_stats, output_dir)
+
+    # draw stagetime profile of individual mice
+    draw_stagetime_profile_individual(stagetime_stats, epoch_len_sec, output_dir)
+
+    # draw stagetime profile of grouped mice
+    draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir)
+
+    # draw stagetime circadian profile of individual mice
+    if is_circadian:
+        draw_stagetime_circadian_profile_indiviudal(stagetime_stats, epoch_len_sec, output_dir)
+
+    # draw stagetime circadian profile of groups
+    if is_circadian:
+        draw_stagetime_circadian_profile_grouped(stagetime_stats, output_dir)
+
+    # draw stagetime barchart
+    draw_stagetime_barchart(stagetime_stats, output_dir)
+
+    # draw stagetime profile of individual mice
+    draw_swtrans_profile_individual(stagetime_stats, epoch_len_sec, output_dir)
+
+    # draw stagetime profile of grouped mice
+    draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir)
+
+    # draw stagetime profile of individual mice
+    if is_circadian:
+        draw_swtrans_circadian_profile_individual(stagetime_stats, epoch_len_sec, output_dir)
+
+    # draw stagetime profile of individual mice
+    if is_circadian:
+        draw_swtrans_circadian_profile_grouped(stagetime_stats, output_dir)
+
+    # draw stage transition barchart (probability)
+    #draw_transition_barchart_prob(stagetime_stats, output_dir)
+
+    # draw stage transition barchart (log odds)
+    #draw_transition_barchart_logodds(stagetime_stats, output_dir)
+
+    # draw sleep/wake transition probability
+    #draw_swtransition_barchart_prob(stagetime_stats, output_dir)
+
+    # draw sleep/wake transition probability (log odds)
+    #draw_swtransition_barchart_logodds(stagetime_stats, output_dir)
+
+    # prepare Powerspectrum density (PSD) profiles for individual mice
+    # list of {simple exp info, target info, psd (epoch_num, 129)} for each mouse
+    psd_info_list = sp.make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq, stage_ext, start_datetime,result_dir_name)
+
+    # log version of psd_info
+    print_log('Making the log version of the PSD information')
+    log_psd_info_list = copy.deepcopy(psd_info_list)
+    for log_psd_info in log_psd_info_list:
+        log_psd_info['norm'] = 10*np.log10(log_psd_info['norm'])
+        log_psd_info['raw'] = 10*np.log10(log_psd_info['raw'])
+
+    # percentage version of psd_info
+    print_log('Making the percentage version of the PSD information')
+    percentage_psd_info_list = copy.deepcopy(psd_info_list)
+    for percentage_psd_info in percentage_psd_info_list:
+        conv_psd = percentage_psd_info['norm']
+        conv_psd_raw = percentage_psd_info['raw']
+        percentage_psd_mat = np.zeros(conv_psd.shape)
+        percentage_psd_raw_mat = np.zeros(conv_psd_raw.shape)
+        for i, p in enumerate(conv_psd): # row wise
+            percentage_psd_mat[i,:] = 100*p / np.sum(p)
+        percentage_psd_info['norm'] = percentage_psd_mat
+        for i, p in enumerate(conv_psd_raw): # row wise
+            percentage_psd_raw_mat[i,:] = 100*p / np.sum(p)
+        percentage_psd_info['raw'] = percentage_psd_raw_mat
+
+    # Save the psd_info_lists
+    print_log('Saving the PSD information')
+    pickle_psd_info_list(psd_info_list, output_dir, 'psd_info_list.pkl')
+
+    # make output dirs for PSDs
+    make_psd_output_dirs(output_dir, 'norm')
+    make_psd_output_dirs(output_dir, 'raw')
+
+    # Make PSD stats and plots
+    process_psd_profile(psd_info_list, log_psd_info_list, percentage_psd_info_list, epoch_len_sec,  sample_freq, output_dir, 'norm')
+    process_psd_profile(psd_info_list, log_psd_info_list, percentage_psd_info_list, epoch_len_sec,  sample_freq, output_dir, 'raw', vol_unit)
+
+    # PSD timeseries
+    #process_psd_timeseries(psd_info_list, percentage_psd_info_list, epoch_range, epoch_len_sec, sample_freq, output_dir, 'norm')
+    #process_psd_timeseries(psd_info_list, percentage_psd_info_list, epoch_range, epoch_len_sec, sample_freq, output_dir, 'raw', vol_unit)
+
+
+def analyze_project(prj_dir: Path, output_dir_name: str, epoch_len_sec: int, result_dir_name: str, faster_dir_list=None) -> None:
+    """Run sleep stage and PSD analysis for the specified project directory."""
+
+    prj_dir = Path(prj_dir)
+    if faster_dir_list is None:
+        faster_dir_list = sorted(
+            str(path)
+            for path in prj_dir.rglob(result_dir_name)
+            if path.is_dir()
+        )
+
+    if not faster_dir_list:
+        raise ValueError("No FASTER2 result directories were found.")
+
+    output_root = prj_dir.with_name(output_dir_name)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    mouse_info = collect_mouse_info_df(faster_dir_list, epoch_len_sec)
+    epoch_range = range(0, mouse_info["epoch_num"])
+
+    do_analysis(
+        faster_dir_list,
+        str(output_root),
+        stage_ext=None,
+        vol_unit="V",
+        epoch_range=epoch_range,
+        epoch_len_sec=epoch_len_sec,
+        is_circadian=False,
+        result_dir_name=result_dir_name,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze staged data and compute PSD/summary statistics")
+    parser.add_argument("--prj-dir", type=Path, required=True, help="Project directory that contains preprocessed results")
+    parser.add_argument("--output-dir-name", default="analyzed", help="Root folder to store analysis outputs")
+    parser.add_argument("--faster-dir-list", nargs="*", default=None, help="Explicit list of FASTER2 result directories to analyze")
+    parser.add_argument("--epoch-len-sec", type=int, default=8, help="Epoch length used during preprocessing")
+    parser.add_argument("--result-dir-name", default="result", help="Name of the preprocessing output directory")
+
+    args = parser.parse_args()
+    analyze_project(
+        args.prj_dir,
+        args.output_dir_name,
+        args.epoch_len_sec,
+        args.result_dir_name,
+        faster_dir_list=args.faster_dir_list,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline_step3_merge.py
+++ b/pipeline_step3_merge.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import argparse
+import json
+import sys
+
+# Ensure repository modules are importable when running in Docker
+sys.path.append('/p-antipsychotics-sleep')
+
+import analysis as ana
+
+
+def merge_and_plot(analyzed_dir_list, rename_dict, exclude_mouse_list, target_group, output_dir, epoch_len_sec, sample_freq):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    merge_result = ana.merge_n_plot(
+        analyzed_dir_list,
+        epoch_len_sec,
+        sample_freq,
+        exclude_mouse_list,
+        target_group,
+        str(output_dir),
+        group_rename_dic=rename_dict,
+    )
+
+    stage_df = (output_dir / "meta_stage_n_bout_df_after.csv")
+    psd_df = (output_dir / "merge_norm_psd_ts_df_after.csv")
+    bout_df = (output_dir / "meta_stage_n_bout_df_after.csv")
+
+    if stage_df.exists() and psd_df.exists() and bout_df.exists():
+        import pandas as pd
+
+        stage_df = pd.read_csv(stage_df)
+        psd_df = pd.read_csv(psd_df)
+        bout_df = pd.read_csv(bout_df)
+
+        for stage in ("NREM", "Wake", "REM"):
+            ana.wilcoxon_n_paried_t(stage_df, psd_df, bout_df, target_group, stage)
+
+    return merge_result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Merge analyzed directories and plot summary figures")
+    parser.add_argument("--analyzed-dir-list", nargs="*", required=True, help="List of analyzed directories to merge")
+    parser.add_argument("--rename-dict", type=str, default="{}", help="Optional group rename mapping as JSON string")
+    parser.add_argument("--exclude-mouse-list", nargs="*", default=[], help="Mouse IDs to exclude from merging")
+    parser.add_argument("--target-group", default="WT", help="Target group name used for statistical tests")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory to store merged outputs")
+    parser.add_argument("--epoch-len-sec", type=int, default=8)
+    parser.add_argument("--sample-freq", type=int, default=128)
+
+    args = parser.parse_args()
+    rename_dict = json.loads(args.rename_dict)
+
+    merge_and_plot(
+        args.analyzed_dir_list,
+        rename_dict,
+        args.exclude_mouse_list,
+        args.target_group,
+        args.output_dir,
+        args.epoch_len_sec,
+        args.sample_freq,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script equivalents for the three pipeline stages with CLI entry points
- switch run_pipeline.py to call the new scripts instead of executing notebooks
- document the new script-based pipeline flow in the README

## Testing
- python -m py_compile run_pipeline.py pipeline_step1_preprocess.py pipeline_step2_analyze.py pipeline_step3_merge.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d02867448331868d012cc6e768f5)