### PR TITLE
Add git clone step to Dockerfile for easier builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 FROM python:3.9-slim
 
+# Repository cloning options
+ARG REPO_URL=https://github.com/yiino1222/eegemg_2025.git
+ARG REPO_REF=main
+
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+# Install git for cloning and clean up apt cache
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY . .
+# Clone the repository directly during build
+RUN git clone --depth 1 --branch "${REPO_REF}" "${REPO_URL}" /tmp/repo \
+    && cp -a /tmp/repo/. /app \
+    && rm -rf /tmp/repo
+
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT ["python", "run_pipeline.py"]
 CMD ["--config", "/config/pipeline.json"]


### PR DESCRIPTION
## Summary
- install git in the image and clone the repository during the Docker build using configurable URL and branch
- keep the existing entrypoint while installing dependencies from the cloned requirements file

## Testing
- not run (container-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440a7cc5cc833182cc11207f698670)