### PR TITLE
Make merge quantification windows configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,28 @@ You can orchestrate everything with `run_pipeline.py` and a JSON config (recomme
     "mouse_groups_to_compare": [],
     "output_dir": "/data/figures/kaist",
     "epoch_len_sec": 8,
-    "sample_freq": 128
+    "sample_freq": 128,
+    "quant_time_windows": {
+      "stage_before": [3, 5],
+      "stage_after": [6, 7],
+      "psd_before": [5, 5],
+      "psd_after": [6, 7],
+      "norm_psd_after": [6, 7]
+    }
   }
 }
 ```
+
+`quant_time_windows` lets you override the time ranges used in Step 3 for aggregation/plots (specified in hours). Each
+entry is a `[start, end]` list; the defaults match the values above. Supported keys:
+
+* `stage_before` / `stage_after`: Stage duration & bout metrics
+* `psd_before` / `psd_after`: Raw PSD summaries
+* `norm_psd_after`: Normalized PSD summaries
+
+When running `pipeline_step3_merge.py` directly, the same mapping can be passed via
+`--quant-time-windows '{"stage_after":[6,7], "psd_after":[6,7]}'`. The selected windows are also printed on the bar plot
+axes so the quantified interval is explicit.
 
 ---
 

--- a/pipeline.config.example.json
+++ b/pipeline.config.example.json
@@ -26,6 +26,13 @@
     "mouse_groups_to_compare": [],
     "output_dir": "/data/figures/kaist",
     "epoch_len_sec": 8,
-    "sample_freq": 128
+    "sample_freq": 128,
+    "quant_time_windows": {
+      "stage_before": [3, 5],
+      "stage_after": [6, 7],
+      "psd_before": [5, 5],
+      "psd_after": [6, 7],
+      "norm_psd_after": [6, 7]
+    }
   }
 }

--- a/pipeline_step3_merge.py
+++ b/pipeline_step3_merge.py
@@ -16,6 +16,7 @@ def merge_and_plot(
     comparison_mode="drug",
     comparison_drug="vehicle",
     mouse_groups_to_compare=None,
+    quant_time_windows=None,
 ):
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -31,6 +32,7 @@ def merge_and_plot(
         comparison_mode=comparison_mode,
         comparison_drug=comparison_drug,
         mouse_groups_to_compare=mouse_groups_to_compare,
+        quant_time_windows=quant_time_windows,
     )
 
     stage_df = (output_dir / "meta_stage_n_bout_df_after.csv")
@@ -76,9 +78,17 @@ def main() -> None:
     parser.add_argument("--output-dir", type=Path, required=True, help="Directory to store merged outputs")
     parser.add_argument("--epoch-len-sec", type=int, default=8)
     parser.add_argument("--sample-freq", type=int, default=128)
+    parser.add_argument(
+        "--quant-time-windows",
+        type=str,
+        default="{}",
+        help="JSON mapping for quantification windows, e.g. "
+        '{"stage_after":[6,7],"psd_after":[6,7],"psd_before":[5,5],"stage_before":[3,5]}',
+    )
 
     args = parser.parse_args()
     rename_dict = json.loads(args.rename_dict)
+    quant_time_windows = json.loads(args.quant_time_windows)
 
     merge_and_plot(
         args.analyzed_dir_list,
@@ -91,6 +101,7 @@ def main() -> None:
         args.comparison_mode,
         args.comparison_drug,
         args.mouse_groups_to_compare,
+        quant_time_windows,
     )
 
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -47,6 +47,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
         "output_dir": "/p-antipsychotics-sleep/figure/output",
         "epoch_len_sec": preprocess["epoch_len_sec"],
         "sample_freq": preprocess["sample_freq"],
+        "quant_time_windows": {},
         **config.get("merge", {}),
     }
 


### PR DESCRIPTION
## Summary
- allow pipeline step3 merge quantification windows to be supplied via config/CLI
- pass configurable time windows through to merge plotting and bar chart labels
- document default windows in the example config and README

## Testing
- python -m compileall analysis.py pipeline_step3_merge.py run_pipeline.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946aff4180c8331b9e950d632932372)