### PR TITLE
Fix type hint for `executed_dir` to use `Optional[Path]`

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pipeline_step1_preprocess import preprocess_project
 from pipeline_step2_analyze import analyze_project
@@ -54,7 +54,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     return {"preprocess": preprocess, "analysis": analysis, "merge": merge}
 
 
-def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:
+def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:
     config = ensure_defaults(load_config(config_path))
     LOGGER.info("Starting preprocessing step")
     preprocess_project(**config["preprocess"])


### PR DESCRIPTION
### Motivation
- The code used the Python 3.10 union type `Path | None` which raises a `TypeError` on older Python interpreters that do not support the `|` type operator.
- Update the annotation to a backwards-compatible form to avoid runtime errors when importing or running the module.
- Preserve the original behavior of `run_pipeline` while improving compatibility.

### Description
- Added `Optional` to the imports from the `typing` module by changing `from typing import Any, Dict` to `from typing import Any, Dict, Optional`.
- Replaced the function signature `def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:` with `def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:`.
- No other functional changes were made; the pipeline logic and default behavior remain unchanged.

### Testing
- No automated tests were run as part of this change.
- The change is limited to type hints and should not affect runtime behavior on Python versions that already support the union operator.
- Manual invocation or CI on older Python versions is recommended to validate compatibility if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e57429708331a845c3f5ee32ced6)