### PR TITLE
Fix analysis lookup for exp.info.csv and backport type hint in run_pipeline

### DIFF
--- a/pipeline_step2_analyze.py
+++ b/pipeline_step2_analyze.py
@@ -90,9 +90,18 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
     epoch_num_stored = None
     sample_freq_stored = None
     for faster_dir in faster_dir_list:
-        data_dir = os.path.join(faster_dir, 'data')
+        data_dir = Path(faster_dir) / "data"
+        if not (data_dir / "exp.info.csv").exists():
+            sibling_data_dir = Path(faster_dir).parent / "data"
+            if (sibling_data_dir / "exp.info.csv").exists():
+                data_dir = sibling_data_dir
+            else:
+                raise FileNotFoundError(
+                    "exp.info.csv was not found under expected data directories. "
+                    f"Tried: {data_dir / 'exp.info.csv'} and {sibling_data_dir / 'exp.info.csv'}"
+                )
 
-        exp_info_df = stage.read_exp_info(data_dir)
+        exp_info_df = stage.read_exp_info(str(data_dir))
         # not used variable: rack_label, start_datetime, end_datetime
         # pylint: disable=unused-variable
         (epoch_num, sample_freq, exp_label, rack_label, \
@@ -106,7 +115,7 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
         else:
             sample_freq_stored = sample_freq
 
-        m_info = stage.read_mouse_info(data_dir)
+        m_info = stage.read_mouse_info(str(data_dir))
         m_info['Experiment label'] = exp_label
         m_info['FASTER_DIR'] = faster_dir
         mouse_info_df = pd.concat([mouse_info_df, m_info])

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pipeline_step1_preprocess import preprocess_project
 from pipeline_step2_analyze import analyze_project
@@ -54,7 +54,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     return {"preprocess": preprocess, "analysis": analysis, "merge": merge}
 
 
-def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:
+def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:
     config = ensure_defaults(load_config(config_path))
     LOGGER.info("Starting preprocessing step")
     preprocess_project(**config["preprocess"])


### PR DESCRIPTION
### Motivation
- Avoid `FileNotFoundError` when `exp.info.csv` is placed next to the recording folder rather than under `result/data` by searching a sibling `data/` directory.
- Make the public API of the pipeline launcher importable on older Python versions by replacing the `|` union type with `Optional` for `executed_dir`.

### Description
- In `pipeline_step2_analyze.py` change `data_dir` construction to use `Path` and check for `exp.info.csv` under `result/data` then fall back to the sibling `data/` directory if present.
- Raise a clear `FileNotFoundError` when `exp.info.csv` is missing in both expected locations and include the attempted paths in the message.
- Pass string paths to `stage.read_exp_info` and `stage.read_mouse_info` by calling them with `str(data_dir)` to preserve the expected API.
- In `run_pipeline.py` import `Optional` and update the signature to `def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:` for Python compatibility.

### Testing
- No automated tests were executed for these changes.
- It is recommended to run CI and a repro of the earlier traceback to validate the `exp.info.csv` lookup fix on real data directories.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e57429708331a845c3f5ee32ced6)