### PR TITLE
Default config path to /data/config.json and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository provides a pipeline for analyzing mouse EEG and EMG data recorde
 docker build -t eegemg-pipeline .
 ```
 
-2. Prepare a config file (see `pipeline.config.example.json`).
+2. Prepare a config file (see `pipeline.config.example.json`) and place it at
+   `/data/config.json` inside the container (mount it there from the host).
 
 3. Run all steps in sequence with a single command
 
@@ -28,8 +29,8 @@ docker build -t eegemg-pipeline .
 # Mount your data directory and config into the container
 docker run --rm \
   -v /your_project:/data \
-  -v /path/to/pipeline.json:/config/pipeline.json \
-  eegemg-pipeline --config /config/pipeline.json
+  -v /path/to/pipeline.json:/data/config.json \
+  eegemg-pipeline
 ```
 
 The pipeline now executes pure Python scripts (no notebook dependency):

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pipeline_step1_preprocess import preprocess_project
 from pipeline_step2_analyze import analyze_project
@@ -54,7 +54,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     return {"preprocess": preprocess, "analysis": analysis, "merge": merge}
 
 
-def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:
+def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:
     config = ensure_defaults(load_config(config_path))
     LOGGER.info("Starting preprocessing step")
     preprocess_project(**config["preprocess"])
@@ -73,8 +73,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config",
         type=Path,
-        required=True,
-        help="Path to JSON configuration file describing inputs and outputs.",
+        default=Path("/data/config.json"),
+        help=(
+            "Path to JSON configuration file describing inputs and outputs "
+            "(default: /data/config.json)."
+        ),
     )
     parser.add_argument(
         "--executed-dir",


### PR DESCRIPTION
### Motivation
- Simplify Docker usage by defaulting the pipeline config to `/data/config.json` so users can omit the `--config` flag when running the container.
- Make the expected runtime convention explicit in the documentation by adding instructions to the `README.md`. 
- Keep the CLI help text accurate so the default location is discoverable from `--help` output. 
- Avoid potential typing incompatibilities by using `Optional` for the `run_pipeline` signature.

### Description
- Set the `--config` CLI argument default to `Path("/data/config.json")` and updated its help text in `run_pipeline.py`.
- Updated the `run_pipeline` signature to `def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:` to use `Optional` typing.
- Revised the Docker example in `README.md` to instruct mounting the config at `/data/config.json` and removed the explicit `--config` invocation in the example `docker run` command.
- Changes were committed to `run_pipeline.py` and `README.md`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e57429708331a845c3f5ee32ced6)