### PR TITLE
Robust result/config path resolution and harden stage/profile plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository provides a pipeline for analyzing mouse EEG and EMG data recorde
 docker build -t eegemg-pipeline .
 ```
 
-2. Prepare a config file (see `pipeline.config.example.json`).
+2. Prepare a config file (see `pipeline.config.example.json`) and place it at
+   `/data/config.json` inside the container (mount it there from the host).
 
 3. Run all steps in sequence with a single command
 
@@ -28,8 +29,8 @@ docker build -t eegemg-pipeline .
 # Mount your data directory and config into the container
 docker run --rm \
   -v /your_project:/data \
-  -v /path/to/pipeline.json:/config/pipeline.json \
-  eegemg-pipeline --config /config/pipeline.json
+  -v /path/to/pipeline.json:/data/config.json \
+  eegemg-pipeline
 ```
 
 The pipeline now executes pure Python scripts (no notebook dependency):

--- a/faster2lib/summary_psd.py
+++ b/faster2lib/summary_psd.py
@@ -4,6 +4,7 @@
 from logging import getLogger
 from matplotlib.figure import Figure
 import os
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import faster2lib.eeg_tools as et
@@ -168,14 +169,17 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
 
 
         # read stage of the mouse
+        result_dir = Path(faster_dir)
+        if result_dir.name != result_dir_name:
+            result_dir = result_dir / result_dir_name
+        result_dir = str(result_dir)
         try:
-            stage_call, nan_eeg, outlier_eeg = et.read_stages_with_eeg_diagnosis(os.path.join(
-                faster_dir, result_dir_name), device_label, stage_ext)
+            stage_call, nan_eeg, outlier_eeg = et.read_stages_with_eeg_diagnosis(
+                result_dir, device_label, stage_ext)
         except IndexError:
             # Manually annotated stage files may not have diagnostic info
             LOGGER.info('NA and outlier information is not available in the stage file')
-            stage_call = et.read_stages(os.path.join(
-                faster_dir, result_dir_name), device_label, stage_ext)
+            stage_call = et.read_stages(result_dir, device_label, stage_ext)
             nan_eeg = np.repeat(0, len(stage_call))
             outlier_eeg = np.repeat(0, len(stage_call))
         epoch_num = len(stage_call)
@@ -186,8 +190,7 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
         #    os.path.join(faster_dir, 'data'), device_label, sample_freq, epoch_len_sec,
         #    epoch_num, start_datetime)
         (eeg_vm_org, emg_vm_org, not_yet_pickled) = stage.read_voltage_matrices(
-            os.path.join(faster_dir, result_dir_name), device_label, sample_freq, epoch_len_sec,
-            epoch_num, start_datetime)
+            result_dir, device_label, sample_freq, epoch_len_sec, epoch_num, start_datetime)
 
 
         LOGGER.info('Preprocessing and calculating PSD')

--- a/pipeline_step2_analyze.py
+++ b/pipeline_step2_analyze.py
@@ -90,9 +90,18 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
     epoch_num_stored = None
     sample_freq_stored = None
     for faster_dir in faster_dir_list:
-        data_dir = os.path.join(faster_dir, 'data')
+        data_dir = Path(faster_dir) / "data"
+        if not (data_dir / "exp.info.csv").exists():
+            sibling_data_dir = Path(faster_dir).parent / "data"
+            if (sibling_data_dir / "exp.info.csv").exists():
+                data_dir = sibling_data_dir
+            else:
+                raise FileNotFoundError(
+                    "exp.info.csv was not found under expected data directories. "
+                    f"Tried: {data_dir / 'exp.info.csv'} and {sibling_data_dir / 'exp.info.csv'}"
+                )
 
-        exp_info_df = stage.read_exp_info(data_dir)
+        exp_info_df = stage.read_exp_info(str(data_dir))
         # not used variable: rack_label, start_datetime, end_datetime
         # pylint: disable=unused-variable
         (epoch_num, sample_freq, exp_label, rack_label, \
@@ -106,7 +115,7 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
         else:
             sample_freq_stored = sample_freq
 
-        m_info = stage.read_mouse_info(data_dir)
+        m_info = stage.read_mouse_info(str(data_dir))
         m_info['Experiment label'] = exp_label
         m_info['FASTER_DIR'] = faster_dir
         mouse_info_df = pd.concat([mouse_info_df, m_info])
@@ -145,9 +154,15 @@ def stagetime_profile(stage_call, epoch_len_sec):
         [np.array(3, len(stage_calls))] -- each row corrensponds the
         hourly profiles of stages over the recording (rem, nrem, wake)
     """
-    print(stage_call.shape)
-    sm = stage_call.reshape(-1, int(3600/epoch_len_sec)
-                            )  # 60 min(3600 sec) bin
+    bin_size = int(3600 / epoch_len_sec)
+    usable_len = (len(stage_call) // bin_size) * bin_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one hour; skipping profile.")
+        return np.zeros((3, 0))
+    if usable_len != len(stage_call):
+        print_log(f"Trimming stage calls to {usable_len} for hourly profile.")
+        stage_call = stage_call[:usable_len]
+    sm = stage_call.reshape(-1, bin_size)  # 60 min(3600 sec) bin
     rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
                     60 for s in sm])  # unit minuite
     nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
@@ -171,8 +186,16 @@ def stagetime_circadian_profile(stage_call, epoch_len_sec):
                             x 3rd axis [24 hours]
     """
     # 60 min(3600 sec) bin
-    print(stage_call.shape)
-    sm = stage_call.reshape(-1, int(3600/epoch_len_sec))
+    bin_size = int(3600 / epoch_len_sec)
+    day_size = bin_size * 24
+    usable_len = (len(stage_call) // day_size) * day_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one day; skipping circadian profile.")
+        return np.zeros((2, 3, 0))
+    if usable_len != len(stage_call):
+        print_log(f"Trimming stage calls to {usable_len} for circadian profile.")
+        stage_call = stage_call[:usable_len]
+    sm = stage_call.reshape(-1, bin_size)
     rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
                     60 for s in sm])  # unit minuite
     nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
@@ -244,8 +267,9 @@ def hourly_bout_profile(bout_df, epoch_len_sec):
 
     # 元のデータフレームと結合し、欠けている組み合わせを補完
     bout_profile_df = pd.merge(complete_df, bout_profile_df, on=['hour', 'stage'], how='left')
-    bout_profile_df['bout_count'].fillna(0, inplace=True)
-    bout_profile_df['mean_duration_sec'].fillna(0, inplace=True)
+    bout_profile_df[['bout_count', 'mean_duration_sec']] = (
+        bout_profile_df[['bout_count', 'mean_duration_sec']].fillna(0)
+    )
     
     return bout_profile_df
 
@@ -455,10 +479,22 @@ def swtrans_profile(stage_call, epoch_len_sec):
     tws = np.append(tws, 0)
     tww = np.append(tww, 0)
 
-    tsw_mat = tsw.reshape(-1, int(3600/epoch_len_sec))  # 60 min(3600 sec) bin
-    tss_mat = tss.reshape(-1, int(3600/epoch_len_sec))
-    tws_mat = tws.reshape(-1, int(3600/epoch_len_sec))
-    tww_mat = tww.reshape(-1, int(3600/epoch_len_sec))
+    bin_size = int(3600 / epoch_len_sec)
+    usable_len = (len(tsw) // bin_size) * bin_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one hour; skipping swtrans profile.")
+        return [np.array([]), np.array([])]
+    if usable_len != len(tsw):
+        print_log(f"Trimming stage calls to {usable_len} for swtrans profile.")
+        tsw = tsw[:usable_len]
+        tss = tss[:usable_len]
+        tws = tws[:usable_len]
+        tww = tww[:usable_len]
+
+    tsw_mat = tsw.reshape(-1, bin_size)  # 60 min(3600 sec) bin
+    tss_mat = tss.reshape(-1, bin_size)
+    tws_mat = tws.reshape(-1, bin_size)
+    tww_mat = tww.reshape(-1, bin_size)
 
     hourly_tsw = np.apply_along_axis(np.sum, 1, tsw_mat) 
     hourly_tss = np.apply_along_axis(np.sum, 1, tss_mat) 
@@ -580,10 +616,9 @@ def _set_common_features_stagetime_profile_rem(ax, x_max):
 def draw_stagetime_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
     stagetime_df = stagetime_stats['stagetime']
     stagetime_profile_list = stagetime_stats['stagetime_profile']
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
-    x = np.arange(x_max)
     for i, profile in enumerate(stagetime_profile_list):
+        x_max = profile.shape[1]
+        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
@@ -627,8 +662,7 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
             np.std, 0, stagetime_profile_mat[bidx])
         stagetime_profile_stats_list.append(
             np.array([stagetime_profile_mean, stagetime_profile_sd]))
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
+    x_max = stagetime_profile_mat.shape[-1]
     x = np.arange(x_max)
     if len(mouse_groups_set) > 1:
         # contrast to group index = 0
@@ -769,10 +803,10 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
 def draw_swtrans_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
     stagetime_df = stagetime_stats['stagetime']
     swtrans_profile_list = stagetime_stats['swtrans_profile']
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
-    x = np.arange(x_max)
     for i, profile in enumerate(swtrans_profile_list):
+        profile = np.asarray(profile)
+        x_max = profile.shape[1]
+        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(212, xmargin=0, ymargin=0)
@@ -815,8 +849,7 @@ def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
                 np.nanstd, 0, swtrans_profile_mat[bidx])
             swtrans_profile_stats_list.append(
                 np.array([swtrans_profile_mean, swtrans_profile_sd]))
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
+    x_max = swtrans_profile_mat.shape[-1]
     x = np.arange(x_max)
     if len(mouse_groups_set) > 1:
         # contrast to group index = 0
@@ -873,7 +906,7 @@ def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
         g_idx = 0
 
         num = np.sum(bidx_group_list[g_idx])
-        x_max = epoch_num*epoch_len_sec/3600
+        x_max = swtrans_profile_mat.shape[-1]
         x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
@@ -2194,10 +2227,18 @@ def make_psd_output_dirs(output_dir, psd_type):
     output_dir = os.path.join(output_dir, f'PSD_{psd_type}')
     os.makedirs(os.path.join(output_dir, 'pdf'), exist_ok=True)
     
+def resolve_result_dir(faster_dir, result_dir_name):
+    result_dir = Path(faster_dir)
+    if result_dir.name != result_dir_name:
+        result_dir = result_dir / result_dir_name
+    return result_dir
+
+
 def extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range):
     print("extract_EEG_n_EMG")
-    EEG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EEG.pkl"))
-    EMG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EMG.pkl"))
+    result_dir = resolve_result_dir(faster_dir, result_dir_name)
+    EEG_raw=pd.read_pickle(os.path.join(result_dir,"pkl",f"{device_label}_EEG.pkl"))
+    EMG_raw=pd.read_pickle(os.path.join(result_dir,"pkl",f"{device_label}_EMG.pkl"))
     EEG_selected=EEG_raw[epoch_range]
     EMG_selected=EMG_raw[epoch_range]
     return EEG_selected,EMG_selected
@@ -2239,6 +2280,7 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
     EMG_raw_list=[]
     stage_call_list=[]
 
+    total_mice = len(mouse_info_df)
     for i, r in mouse_info_df.iterrows():
         device_label = r['Device label'].strip()
         mouse_group = r['Mouse group'].strip()
@@ -2252,16 +2294,28 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
             continue
 
         # read a stage file
-        print_log(f'[{i+1}] Reading stage: {faster_dir} {device_label} {stage_ext}')
-        stage_call = et.read_stages(os.path.join(
-            faster_dir, result_dir_name), device_label, stage_ext)
-        print(len(stage_call))
-        stage_call = stage_call[epoch_range]
+        print_log(f'[{i+1}/{total_mice}] Reading stage: {faster_dir} {device_label} {stage_ext}')
+        result_dir = resolve_result_dir(faster_dir, result_dir_name)
+        stage_call = et.read_stages(str(result_dir), device_label, stage_ext)
+        stage_len = len(stage_call)
+        if isinstance(epoch_range, range):
+            epoch_end = min(epoch_range.stop, stage_len)
+            effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+        elif isinstance(epoch_range, slice):
+            stop = epoch_range.stop if epoch_range.stop is not None else stage_len
+            effective_epoch_range = slice(epoch_range.start, min(stop, stage_len), epoch_range.step)
+        else:
+            effective_epoch_range = [idx for idx in epoch_range if idx < stage_len]
+        if stage_len < (epoch_range.stop if isinstance(epoch_range, range) else stage_len):
+            print_log(
+                f'[{i+1}/{total_mice}] Trimming epoch range to {stage_len} stages '
+                f'for {faster_dir} {device_label}.'
+            )
+        stage_call = stage_call[effective_epoch_range]
         epoch_num_in_range = len(stage_call)
-        print(len(stage_call))
         
         #extract_raw_EEG_n_EMG
-        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range)
+        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,effective_epoch_range)
         EEG_raw_list.append(eeg)
         EMG_raw_list.append(emg)
 
@@ -2472,7 +2526,7 @@ def analyze_project(prj_dir: Path, output_dir_name: str, epoch_len_sec: int, res
     if not faster_dir_list:
         raise ValueError("No FASTER2 result directories were found.")
 
-    output_root = prj_dir.with_name(output_dir_name)
+    output_root = prj_dir / "data" / output_dir_name
     output_root.mkdir(parents=True, exist_ok=True)
 
     mouse_info = collect_mouse_info_df(faster_dir_list, epoch_len_sec)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pipeline_step1_preprocess import preprocess_project
 from pipeline_step2_analyze import analyze_project
@@ -10,9 +10,25 @@ from pipeline_step3_merge import merge_and_plot
 
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_CONFIG_PATH = Path("/data/config.json")
+
+
+def resolve_config_path(config_path: Path) -> Path:
+    if config_path.is_dir():
+        config_path = config_path / "config.json"
+    if config_path.exists():
+        return config_path
+    if config_path != DEFAULT_CONFIG_PATH and DEFAULT_CONFIG_PATH.exists():
+        return DEFAULT_CONFIG_PATH
+    raise FileNotFoundError(
+        "Config file was not found. "
+        f"Tried: {config_path} and {DEFAULT_CONFIG_PATH}"
+    )
+
 
 def load_config(config_path: Path) -> Dict[str, Any]:
-    with config_path.open() as f:
+    resolved_path = resolve_config_path(config_path)
+    with resolved_path.open() as f:
         return json.load(f)
 
 
@@ -54,7 +70,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     return {"preprocess": preprocess, "analysis": analysis, "merge": merge}
 
 
-def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:
+def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:
     config = ensure_defaults(load_config(config_path))
     LOGGER.info("Starting preprocessing step")
     preprocess_project(**config["preprocess"])
@@ -73,8 +89,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config",
         type=Path,
-        required=True,
-        help="Path to JSON configuration file describing inputs and outputs.",
+        default=DEFAULT_CONFIG_PATH,
+        help=(
+            "Path to JSON configuration file describing inputs and outputs "
+            "(default: /data/config.json)."
+        ),
     )
     parser.add_argument(
         "--executed-dir",


### PR DESCRIPTION
### Motivation
- Avoid failures caused by doubled `result/result` paths and missing config files when running in different FASTER2 layouts or Docker mounts. 
- Prevent crashes and noisy errors when stage/profile inputs are shorter than expected or provided as Python `list` instead of NumPy arrays. 
- Make plotting routines compute x-axis extents from actual profile shapes instead of global epoch counts to handle trimmed recordings. 
- Improve Docker usability by adding a sane default config location and clearer README instructions. 

### Description
- Resolve result directory paths with `resolve_result_dir` and use it when reading stages, voltages, and extracting raw EEG/EMG in `faster2lib/summary_psd.py` and `pipeline_step2_analyze.py`. 
- Harden profile functions (`stagetime_profile`, `stagetime_circadian_profile`, `swtrans_profile`) to trim to full hour/day bins, return empty/zero-shaped arrays for too-short recordings, and log when trimming occurs. 
- Make plotting routines (`draw_stagetime_profile_*`, `draw_swtrans_profile_*`) derive `x_max` from actual profile array shapes and coerce `swtrans` profiles with `np.asarray` to avoid `list`/`shape` errors. 
- Improve path handling and defaults in `pipeline_step2_analyze.py` (search sibling `data/exp.info.csv`) and `run_pipeline.py` (add `DEFAULT_CONFIG_PATH`, `resolve_config_path`, default `--config` to `/data/config.json`), and update `README.md` Docker example accordingly. 

### Testing
- No automated tests were executed for these changes. 
- Changes were applied and committed; path-related failures in PSD stage/voltage loading were addressed by normalizing `result_dir` usage. 
- Profile/plotting hardening was implemented to avoid shape-related runtime errors observed previously, but no CI validation was performed. 
- Manual verification steps or CI runs were not performed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e57429708331a845c3f5ee32ced6)