### PR TITLE
Fix PSD mask/epoch-range mismatches and harden stage/profile and path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository provides a pipeline for analyzing mouse EEG and EMG data recorde
 docker build -t eegemg-pipeline .
 ```
 
-2. Prepare a config file (see `pipeline.config.example.json`).
+2. Prepare a config file (see `pipeline.config.example.json`) and place it at
+   `/data/config.json` inside the container (mount it there from the host).
 
 3. Run all steps in sequence with a single command
 
@@ -28,8 +29,8 @@ docker build -t eegemg-pipeline .
 # Mount your data directory and config into the container
 docker run --rm \
   -v /your_project:/data \
-  -v /path/to/pipeline.json:/config/pipeline.json \
-  eegemg-pipeline --config /config/pipeline.json
+  -v /path/to/pipeline.json:/data/config.json \
+  eegemg-pipeline
 ```
 
 The pipeline now executes pure Python scripts (no notebook dependency):

--- a/faster2lib/summary_psd.py
+++ b/faster2lib/summary_psd.py
@@ -4,6 +4,7 @@
 from logging import getLogger
 from matplotlib.figure import Figure
 import os
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import faster2lib.eeg_tools as et
@@ -69,11 +70,19 @@ def make_psd_profile(psd_info_list, sample_freq, epoch_len_sec, psd_type='norm',
 
         # Default mask
         if mask is None:
-            mask = np.full(len(psd_info['bidx_target']), True)
+            current_mask = np.full(len(psd_info['bidx_target']), True)
+        else:
+            current_len = len(psd_info['bidx_target'])
+            if len(mask) >= current_len:
+                current_mask = mask[:current_len]
+            else:
+                current_mask = np.concatenate(
+                    [mask, np.full(current_len - len(mask), False)]
+                )
 
-        bidx_rem_target = psd_info['bidx_rem'] & psd_info['bidx_target'] & mask
-        bidx_nrem_target = psd_info['bidx_nrem'] & psd_info['bidx_target'] & mask
-        bidx_wake_target = psd_info['bidx_wake'] & psd_info['bidx_target'] & mask
+        bidx_rem_target = psd_info['bidx_rem'] & psd_info['bidx_target'] & current_mask
+        bidx_nrem_target = psd_info['bidx_nrem'] & psd_info['bidx_target'] & current_mask
+        bidx_wake_target = psd_info['bidx_wake'] & psd_info['bidx_target'] & current_mask
 
         psd_summary_rem = _psd_summary_by_bidx(bidx_rem_target)
         psd_summary_nrem = _psd_summary_by_bidx(bidx_nrem_target)
@@ -95,9 +104,9 @@ def make_psd_profile(psd_info_list, sample_freq, epoch_len_sec, psd_type='norm',
                 hour_mask = np.zeros(total_epochs, dtype=bool)
                 hour_mask[hour * epochs_per_hour:(hour + 1) * epochs_per_hour] = True
 
-                bidx_rem_hourly = (psd_info['stage_call'] == "REM") & mask & hour_mask
-                bidx_nrem_hourly = (psd_info['stage_call'] == "NREM") & mask & hour_mask
-                bidx_wake_hourly = (psd_info['stage_call'] == "WAKE") & mask & hour_mask
+                bidx_rem_hourly = (psd_info['stage_call'] == "REM") & current_mask & hour_mask
+                bidx_nrem_hourly = (psd_info['stage_call'] == "NREM") & current_mask & hour_mask
+                bidx_wake_hourly = (psd_info['stage_call'] == "WAKE") & current_mask & hour_mask
 
                 psd_summary_rem_hourly = _psd_summary_by_bidx(bidx_rem_hourly)
                 psd_summary_nrem_hourly = _psd_summary_by_bidx(bidx_nrem_hourly)
@@ -168,14 +177,17 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
 
 
         # read stage of the mouse
+        result_dir = Path(faster_dir)
+        if result_dir.name != result_dir_name:
+            result_dir = result_dir / result_dir_name
+        result_dir = str(result_dir)
         try:
-            stage_call, nan_eeg, outlier_eeg = et.read_stages_with_eeg_diagnosis(os.path.join(
-                faster_dir, result_dir_name), device_label, stage_ext)
+            stage_call, nan_eeg, outlier_eeg = et.read_stages_with_eeg_diagnosis(
+                result_dir, device_label, stage_ext)
         except IndexError:
             # Manually annotated stage files may not have diagnostic info
             LOGGER.info('NA and outlier information is not available in the stage file')
-            stage_call = et.read_stages(os.path.join(
-                faster_dir, result_dir_name), device_label, stage_ext)
+            stage_call = et.read_stages(result_dir, device_label, stage_ext)
             nan_eeg = np.repeat(0, len(stage_call))
             outlier_eeg = np.repeat(0, len(stage_call))
         epoch_num = len(stage_call)
@@ -186,8 +198,7 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
         #    os.path.join(faster_dir, 'data'), device_label, sample_freq, epoch_len_sec,
         #    epoch_num, start_datetime)
         (eeg_vm_org, emg_vm_org, not_yet_pickled) = stage.read_voltage_matrices(
-            os.path.join(faster_dir, result_dir_name), device_label, sample_freq, epoch_len_sec,
-            epoch_num, start_datetime)
+            result_dir, device_label, sample_freq, epoch_len_sec, epoch_num, start_datetime)
 
 
         LOGGER.info('Preprocessing and calculating PSD')
@@ -213,20 +224,42 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
         # good PSD should have the nan- and outlier-ratios of less than 1%
         bidx_good_psd = (nan_eeg < 0.01) & (outlier_eeg < 0.01)
 
+        if isinstance(epoch_range, range):
+            epoch_end = min(epoch_range.stop, epoch_num)
+            effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+        elif isinstance(epoch_range, slice):
+            stop = epoch_range.stop if epoch_range.stop is not None else epoch_num
+            effective_epoch_range = slice(epoch_range.start, min(stop, epoch_num), epoch_range.step)
+        else:
+            effective_epoch_range = [idx for idx in epoch_range if idx < epoch_num]
+
         # bidx_target: bidx for the good epochs in the selected range
         bidx_selected = np.repeat(False, epoch_num)
-        bidx_selected[epoch_range] = True
+        bidx_selected[effective_epoch_range] = True
         bidx_target = bidx_selected & bidx_good_psd & ~bidx_unknown
+
+        if isinstance(effective_epoch_range, range):
+            range_start = effective_epoch_range.start
+            range_stop = effective_epoch_range.stop
+            range_len = range_stop - range_start
+        elif isinstance(effective_epoch_range, slice):
+            range_start = effective_epoch_range.start or 0
+            range_stop = effective_epoch_range.stop or epoch_num
+            range_len = len(range(range_start, range_stop, effective_epoch_range.step or 1))
+        else:
+            range_start = min(effective_epoch_range) if effective_epoch_range else 0
+            range_stop = (max(effective_epoch_range) + 1) if effective_epoch_range else 0
+            range_len = len(effective_epoch_range)
+        selected_count = np.sum(bidx_selected)
 
         LOGGER.info('    Target epoch range: %d-%d (%d epochs out of %d epochs)\n'\
                     '    Unknown epochs in the range: %d (%.3f %%)\n'\
                     '    Outlier or NA epochs in the range: %d (%.3f %%)',
-                    epoch_range.start, epoch_range.stop,
-                    epoch_range.stop - epoch_range.start, epoch_num,
+                    range_start, range_stop, range_len, epoch_num,
                     np.sum(bidx_unknown & bidx_selected), 100 *
-                    np.sum(bidx_unknown & bidx_selected)/np.sum(bidx_selected),
+                    np.sum(bidx_unknown & bidx_selected)/max(selected_count, 1),
                     np.sum(~bidx_good_psd & bidx_selected),
-                    100*np.sum(~bidx_good_psd & bidx_selected)/np.sum(bidx_selected))
+                    100*np.sum(~bidx_good_psd & bidx_selected)/max(selected_count, 1))
 
 
         bidx_rem = (stage_call == 'REM') & bidx_target
@@ -262,14 +295,14 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
                               'mouse_group': mouse_group,
                               'mouse_id': mouse_id,
                               'device_label': device_label,
-                              'stage_call': stage_call[epoch_range],
-                              'bidx_rem': bidx_rem[epoch_range],
-                              'bidx_nrem': bidx_nrem[epoch_range],
-                              'bidx_wake': bidx_wake[epoch_range],
-                              'bidx_unknown': bidx_unknown[epoch_range],
-                              'bidx_target': bidx_target[epoch_range],
-                              'norm': conv_psd[epoch_range],
-                              'raw': conv_psd_raw[epoch_range]})
+                              'stage_call': stage_call[effective_epoch_range],
+                              'bidx_rem': bidx_rem[effective_epoch_range],
+                              'bidx_nrem': bidx_nrem[effective_epoch_range],
+                              'bidx_wake': bidx_wake[effective_epoch_range],
+                              'bidx_unknown': bidx_unknown[effective_epoch_range],
+                              'bidx_target': bidx_target[effective_epoch_range],
+                              'norm': conv_psd[effective_epoch_range],
+                              'raw': conv_psd_raw[effective_epoch_range]})
 
     return psd_info_list
 
@@ -407,6 +440,27 @@ def make_psd_timeseries_df(psd_info_list, epoch_range, bidx_freq, stage_bidx_key
     Returns:
         [pd.dataframe]: The timeseries of PSD
     """
+    if not psd_info_list:
+        return pd.DataFrame()
+    min_epoch_num = min(len(psd_info['bidx_target']) for psd_info in psd_info_list)
+    if isinstance(epoch_range, range):
+        epoch_end = min(epoch_range.stop, min_epoch_num)
+        effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+    elif isinstance(epoch_range, slice):
+        stop = epoch_range.stop if epoch_range.stop is not None else min_epoch_num
+        effective_epoch_range = slice(epoch_range.start, min(stop, min_epoch_num), epoch_range.step)
+    else:
+        effective_epoch_range = [idx for idx in epoch_range if idx < min_epoch_num]
+
+    if isinstance(effective_epoch_range, range):
+        range_len = effective_epoch_range.stop - effective_epoch_range.start
+    elif isinstance(effective_epoch_range, slice):
+        range_len = len(range(effective_epoch_range.start or 0,
+                              effective_epoch_range.stop or min_epoch_num,
+                              effective_epoch_range.step or 1))
+    else:
+        range_len = len(effective_epoch_range)
+
     psd_timeseries_df = pd.DataFrame()
     for psd_info in psd_info_list:
         bidx_target = psd_info['bidx_target']
@@ -417,8 +471,9 @@ def make_psd_timeseries_df(psd_info_list, epoch_range, bidx_freq, stage_bidx_key
             bidx_targeted_stage = bidx_target
 
         conv_psd = psd_info[psd_type]
-        psd_delta_timeseries = np.repeat(np.nan, epoch_range.stop - epoch_range.start)
-        psd_delta_timeseries[bidx_targeted_stage[epoch_range]] = np.apply_along_axis(np.nanmean, 1, conv_psd[bidx_targeted_stage, :][:,bidx_freq])
+        psd_delta_timeseries = np.repeat(np.nan, range_len)
+        psd_delta_timeseries[bidx_targeted_stage[effective_epoch_range]] = np.apply_along_axis(
+            np.nanmean, 1, conv_psd[bidx_targeted_stage, :][:, bidx_freq])
         #psd_timeseries_df = psd_timeseries_df.append(
         #    [[psd_info['exp_label'], psd_info['mouse_group'], psd_info['mouse_id'], psd_info['device_label']] + psd_delta_timeseries.tolist()], ignore_index=True)
         # 新しい行データを準備
@@ -429,7 +484,16 @@ def make_psd_timeseries_df(psd_info_list, epoch_range, bidx_freq, stage_bidx_key
 
         # pd.concatを使用してDataFrameを更新
         psd_timeseries_df = pd.concat([psd_timeseries_df, new_row], ignore_index=True)
-    epoch_columns = [f'epoch{x+1}' for x in np.arange(epoch_range.start, epoch_range.stop)]
+    if isinstance(effective_epoch_range, range):
+        epoch_indices = np.arange(effective_epoch_range.start, effective_epoch_range.stop,
+                                  effective_epoch_range.step)
+    elif isinstance(effective_epoch_range, slice):
+        epoch_indices = np.arange(effective_epoch_range.start or 0,
+                                  effective_epoch_range.stop or min_epoch_num,
+                                  effective_epoch_range.step or 1)
+    else:
+        epoch_indices = np.array(effective_epoch_range)
+    epoch_columns = [f'epoch{x+1}' for x in epoch_indices]
     column_names = ['Experiment label', 'Mouse group', 'Mouse ID', 'Device label'] + epoch_columns
     psd_timeseries_df.columns = column_names
 

--- a/pipeline_step2_analyze.py
+++ b/pipeline_step2_analyze.py
@@ -90,9 +90,18 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
     epoch_num_stored = None
     sample_freq_stored = None
     for faster_dir in faster_dir_list:
-        data_dir = os.path.join(faster_dir, 'data')
+        data_dir = Path(faster_dir) / "data"
+        if not (data_dir / "exp.info.csv").exists():
+            sibling_data_dir = Path(faster_dir).parent / "data"
+            if (sibling_data_dir / "exp.info.csv").exists():
+                data_dir = sibling_data_dir
+            else:
+                raise FileNotFoundError(
+                    "exp.info.csv was not found under expected data directories. "
+                    f"Tried: {data_dir / 'exp.info.csv'} and {sibling_data_dir / 'exp.info.csv'}"
+                )
 
-        exp_info_df = stage.read_exp_info(data_dir)
+        exp_info_df = stage.read_exp_info(str(data_dir))
         # not used variable: rack_label, start_datetime, end_datetime
         # pylint: disable=unused-variable
         (epoch_num, sample_freq, exp_label, rack_label, \
@@ -106,7 +115,7 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
         else:
             sample_freq_stored = sample_freq
 
-        m_info = stage.read_mouse_info(data_dir)
+        m_info = stage.read_mouse_info(str(data_dir))
         m_info['Experiment label'] = exp_label
         m_info['FASTER_DIR'] = faster_dir
         mouse_info_df = pd.concat([mouse_info_df, m_info])
@@ -145,9 +154,15 @@ def stagetime_profile(stage_call, epoch_len_sec):
         [np.array(3, len(stage_calls))] -- each row corrensponds the
         hourly profiles of stages over the recording (rem, nrem, wake)
     """
-    print(stage_call.shape)
-    sm = stage_call.reshape(-1, int(3600/epoch_len_sec)
-                            )  # 60 min(3600 sec) bin
+    bin_size = int(3600 / epoch_len_sec)
+    usable_len = (len(stage_call) // bin_size) * bin_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one hour; skipping profile.")
+        return np.zeros((3, 0))
+    if usable_len != len(stage_call):
+        print_log(f"Trimming stage calls to {usable_len} for hourly profile.")
+        stage_call = stage_call[:usable_len]
+    sm = stage_call.reshape(-1, bin_size)  # 60 min(3600 sec) bin
     rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
                     60 for s in sm])  # unit minuite
     nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
@@ -171,8 +186,16 @@ def stagetime_circadian_profile(stage_call, epoch_len_sec):
                             x 3rd axis [24 hours]
     """
     # 60 min(3600 sec) bin
-    print(stage_call.shape)
-    sm = stage_call.reshape(-1, int(3600/epoch_len_sec))
+    bin_size = int(3600 / epoch_len_sec)
+    day_size = bin_size * 24
+    usable_len = (len(stage_call) // day_size) * day_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one day; skipping circadian profile.")
+        return np.zeros((2, 3, 0))
+    if usable_len != len(stage_call):
+        print_log(f"Trimming stage calls to {usable_len} for circadian profile.")
+        stage_call = stage_call[:usable_len]
+    sm = stage_call.reshape(-1, bin_size)
     rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
                     60 for s in sm])  # unit minuite
     nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
@@ -244,8 +267,9 @@ def hourly_bout_profile(bout_df, epoch_len_sec):
 
     # 元のデータフレームと結合し、欠けている組み合わせを補完
     bout_profile_df = pd.merge(complete_df, bout_profile_df, on=['hour', 'stage'], how='left')
-    bout_profile_df['bout_count'].fillna(0, inplace=True)
-    bout_profile_df['mean_duration_sec'].fillna(0, inplace=True)
+    bout_profile_df[['bout_count', 'mean_duration_sec']] = (
+        bout_profile_df[['bout_count', 'mean_duration_sec']].fillna(0)
+    )
     
     return bout_profile_df
 
@@ -455,10 +479,22 @@ def swtrans_profile(stage_call, epoch_len_sec):
     tws = np.append(tws, 0)
     tww = np.append(tww, 0)
 
-    tsw_mat = tsw.reshape(-1, int(3600/epoch_len_sec))  # 60 min(3600 sec) bin
-    tss_mat = tss.reshape(-1, int(3600/epoch_len_sec))
-    tws_mat = tws.reshape(-1, int(3600/epoch_len_sec))
-    tww_mat = tww.reshape(-1, int(3600/epoch_len_sec))
+    bin_size = int(3600 / epoch_len_sec)
+    usable_len = (len(tsw) // bin_size) * bin_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one hour; skipping swtrans profile.")
+        return [np.array([]), np.array([])]
+    if usable_len != len(tsw):
+        print_log(f"Trimming stage calls to {usable_len} for swtrans profile.")
+        tsw = tsw[:usable_len]
+        tss = tss[:usable_len]
+        tws = tws[:usable_len]
+        tww = tww[:usable_len]
+
+    tsw_mat = tsw.reshape(-1, bin_size)  # 60 min(3600 sec) bin
+    tss_mat = tss.reshape(-1, bin_size)
+    tws_mat = tws.reshape(-1, bin_size)
+    tww_mat = tww.reshape(-1, bin_size)
 
     hourly_tsw = np.apply_along_axis(np.sum, 1, tsw_mat) 
     hourly_tss = np.apply_along_axis(np.sum, 1, tss_mat) 
@@ -580,10 +616,9 @@ def _set_common_features_stagetime_profile_rem(ax, x_max):
 def draw_stagetime_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
     stagetime_df = stagetime_stats['stagetime']
     stagetime_profile_list = stagetime_stats['stagetime_profile']
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
-    x = np.arange(x_max)
     for i, profile in enumerate(stagetime_profile_list):
+        x_max = profile.shape[1]
+        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
@@ -627,8 +662,7 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
             np.std, 0, stagetime_profile_mat[bidx])
         stagetime_profile_stats_list.append(
             np.array([stagetime_profile_mean, stagetime_profile_sd]))
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
+    x_max = stagetime_profile_mat.shape[-1]
     x = np.arange(x_max)
     if len(mouse_groups_set) > 1:
         # contrast to group index = 0
@@ -769,10 +803,10 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
 def draw_swtrans_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
     stagetime_df = stagetime_stats['stagetime']
     swtrans_profile_list = stagetime_stats['swtrans_profile']
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
-    x = np.arange(x_max)
     for i, profile in enumerate(swtrans_profile_list):
+        profile = np.asarray(profile)
+        x_max = profile.shape[1]
+        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(212, xmargin=0, ymargin=0)
@@ -815,8 +849,7 @@ def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
                 np.nanstd, 0, swtrans_profile_mat[bidx])
             swtrans_profile_stats_list.append(
                 np.array([swtrans_profile_mean, swtrans_profile_sd]))
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
+    x_max = swtrans_profile_mat.shape[-1]
     x = np.arange(x_max)
     if len(mouse_groups_set) > 1:
         # contrast to group index = 0
@@ -873,7 +906,7 @@ def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
         g_idx = 0
 
         num = np.sum(bidx_group_list[g_idx])
-        x_max = epoch_num*epoch_len_sec/3600
+        x_max = swtrans_profile_mat.shape[-1]
         x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
@@ -2194,10 +2227,18 @@ def make_psd_output_dirs(output_dir, psd_type):
     output_dir = os.path.join(output_dir, f'PSD_{psd_type}')
     os.makedirs(os.path.join(output_dir, 'pdf'), exist_ok=True)
     
+def resolve_result_dir(faster_dir, result_dir_name):
+    result_dir = Path(faster_dir)
+    if result_dir.name != result_dir_name:
+        result_dir = result_dir / result_dir_name
+    return result_dir
+
+
 def extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range):
     print("extract_EEG_n_EMG")
-    EEG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EEG.pkl"))
-    EMG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EMG.pkl"))
+    result_dir = resolve_result_dir(faster_dir, result_dir_name)
+    EEG_raw=pd.read_pickle(os.path.join(result_dir,"pkl",f"{device_label}_EEG.pkl"))
+    EMG_raw=pd.read_pickle(os.path.join(result_dir,"pkl",f"{device_label}_EMG.pkl"))
     EEG_selected=EEG_raw[epoch_range]
     EMG_selected=EMG_raw[epoch_range]
     return EEG_selected,EMG_selected
@@ -2239,6 +2280,7 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
     EMG_raw_list=[]
     stage_call_list=[]
 
+    total_mice = len(mouse_info_df)
     for i, r in mouse_info_df.iterrows():
         device_label = r['Device label'].strip()
         mouse_group = r['Mouse group'].strip()
@@ -2252,16 +2294,28 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
             continue
 
         # read a stage file
-        print_log(f'[{i+1}] Reading stage: {faster_dir} {device_label} {stage_ext}')
-        stage_call = et.read_stages(os.path.join(
-            faster_dir, result_dir_name), device_label, stage_ext)
-        print(len(stage_call))
-        stage_call = stage_call[epoch_range]
+        print_log(f'[{i+1}/{total_mice}] Reading stage: {faster_dir} {device_label} {stage_ext}')
+        result_dir = resolve_result_dir(faster_dir, result_dir_name)
+        stage_call = et.read_stages(str(result_dir), device_label, stage_ext)
+        stage_len = len(stage_call)
+        if isinstance(epoch_range, range):
+            epoch_end = min(epoch_range.stop, stage_len)
+            effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+        elif isinstance(epoch_range, slice):
+            stop = epoch_range.stop if epoch_range.stop is not None else stage_len
+            effective_epoch_range = slice(epoch_range.start, min(stop, stage_len), epoch_range.step)
+        else:
+            effective_epoch_range = [idx for idx in epoch_range if idx < stage_len]
+        if stage_len < (epoch_range.stop if isinstance(epoch_range, range) else stage_len):
+            print_log(
+                f'[{i+1}/{total_mice}] Trimming epoch range to {stage_len} stages '
+                f'for {faster_dir} {device_label}.'
+            )
+        stage_call = stage_call[effective_epoch_range]
         epoch_num_in_range = len(stage_call)
-        print(len(stage_call))
         
         #extract_raw_EEG_n_EMG
-        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range)
+        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,effective_epoch_range)
         EEG_raw_list.append(eeg)
         EMG_raw_list.append(emg)
 
@@ -2472,7 +2526,7 @@ def analyze_project(prj_dir: Path, output_dir_name: str, epoch_len_sec: int, res
     if not faster_dir_list:
         raise ValueError("No FASTER2 result directories were found.")
 
-    output_root = prj_dir.with_name(output_dir_name)
+    output_root = prj_dir / "data" / output_dir_name
     output_root.mkdir(parents=True, exist_ok=True)
 
     mouse_info = collect_mouse_info_df(faster_dir_list, epoch_len_sec)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pipeline_step1_preprocess import preprocess_project
 from pipeline_step2_analyze import analyze_project
@@ -10,9 +10,25 @@ from pipeline_step3_merge import merge_and_plot
 
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_CONFIG_PATH = Path("/data/config.json")
+
+
+def resolve_config_path(config_path: Path) -> Path:
+    if config_path.is_dir():
+        config_path = config_path / "config.json"
+    if config_path.exists():
+        return config_path
+    if config_path != DEFAULT_CONFIG_PATH and DEFAULT_CONFIG_PATH.exists():
+        return DEFAULT_CONFIG_PATH
+    raise FileNotFoundError(
+        "Config file was not found. "
+        f"Tried: {config_path} and {DEFAULT_CONFIG_PATH}"
+    )
+
 
 def load_config(config_path: Path) -> Dict[str, Any]:
-    with config_path.open() as f:
+    resolved_path = resolve_config_path(config_path)
+    with resolved_path.open() as f:
         return json.load(f)
 
 
@@ -54,7 +70,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     return {"preprocess": preprocess, "analysis": analysis, "merge": merge}
 
 
-def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:
+def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:
     config = ensure_defaults(load_config(config_path))
     LOGGER.info("Starting preprocessing step")
     preprocess_project(**config["preprocess"])
@@ -73,8 +89,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config",
         type=Path,
-        required=True,
-        help="Path to JSON configuration file describing inputs and outputs.",
+        default=DEFAULT_CONFIG_PATH,
+        help=(
+            "Path to JSON configuration file describing inputs and outputs "
+            "(default: /data/config.json)."
+        ),
     )
     parser.add_argument(
         "--executed-dir",


### PR DESCRIPTION
### Motivation

- Prevent shape-mismatch errors when a global `mask` length does not match per-recording stage lengths during PSD summaries.  
- Avoid crashes and noisy errors for very-short recordings when computing hourly/circadian/stwtrans profiles.  
- Make result/config path resolution robust to common FASTER2 directory layouts and Docker mounts.  

### Description

- In `faster2lib/summary_psd.py` compute a per-recording `current_mask` by padding or trimming the provided `mask`, clamp and slice epoch ranges into an `effective_epoch_range`, and store per-recording arrays using that clamped range.  
- Harden PSD timeseries code in `make_psd_timeseries_df` to compute a consistent `effective_epoch_range` across recordings and derive epoch column names from actual indices.  
- In `pipeline_step2_analyze.py` make data/result path resolution tolerant of sibling/nested layouts, add `resolve_result_dir`, use it in `extract_raw_EEG_n_EMG`, and trim `stage_call` to full hour/day bins for `stagetime_profile`, `stagetime_circadian_profile`, and `swtrans_profile` returning empty/zero-shaped arrays for too-short recordings.  
- Add Docker-friendly config defaults and resolution in `run_pipeline.py` with `DEFAULT_CONFIG_PATH` and `resolve_config_path`, and update the README Docker guidance to use `/data/config.json`.  

### Testing

- No automated tests were run for these changes.  
- The changes address the previously observed `ValueError` from mismatched PSD mask shapes by ensuring per-recording masks are aligned (manual reproduction not included in automated tests).  
- No CI runs were executed.  
- Recommend adding unit tests for epoch-range clamping, per-recording mask handling, and very-short-recording profile behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e57429708331a845c3f5ee32ced6)