### PR TITLE
Stop writing window-labeled output files; rely on window-specific folders

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
 import os
+from pathlib import Path
 import numpy as np
 import pickle
 import argparse
 import copy
+import re
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -189,6 +191,7 @@ def make_df_from_summary_dic(stats_fname):
     data_array = stats["stagetime_profile"]
     transition_array = stats["swtrans_profile"]  # [hourly_psw, hourly_pws]
     bout_array = stats["bout_profile"]
+    time_offset = stats.get("time_in_hour_offset", 0)
     
     # リストを用意
     stage_merge_list = []
@@ -205,7 +208,7 @@ def make_df_from_summary_dic(stats_fname):
             "mouse_ID": df_exp_info['Mouse ID'][i],
             "hourly_psw": transition_array[i][0],
             "hourly_pws": transition_array[i][1],
-            "time_in_hour": np.arange(len(transition_array[i][0]))
+            "time_in_hour": np.arange(len(transition_array[i][0])) + time_offset
         })
         sw_transition_merge_list.append(df_swtansition_append)
         
@@ -232,7 +235,7 @@ def make_df_from_summary_dic(stats_fname):
                     "stage": stage,
                     "bout_count": [bout_count],
                     "mean_duration_sec": [mean_duration_sec],
-                    "time_in_hour": [hour]
+                    "time_in_hour": [hour + time_offset]
                 })
                 stage_bout_merge_list.append(stage_bout_append)
         
@@ -244,7 +247,7 @@ def make_df_from_summary_dic(stats_fname):
                 "mouse_ID": df_exp_info['Mouse ID'][i],
                 "stage": stage,
                 "min_per_hour": data_array[i][j],
-                "time_in_hour": np.arange(len(data_array[i][j]))
+                "time_in_hour": np.arange(len(data_array[i][j])) + time_offset
             })
             stage_merge_list.append(df_append)
     
@@ -257,6 +260,11 @@ def make_df_from_summary_dic(stats_fname):
     stage_merge_df = stage_merge_df.set_index(["exp_label", "mouse_group", "mouse_ID", "stage", "time_in_hour"])
     sw_transition_merge_df = sw_transition_merge_df.set_index(["exp_label", "mouse_group", "mouse_ID", "time_in_hour"])
     stage_bout_merge_df = stage_bout_merge_df.set_index(["exp_label", "mouse_group", "mouse_ID", "stage", "time_in_hour"])
+
+    if not stage_merge_df.empty:
+        time_vals = stage_merge_df.index.get_level_values("time_in_hour")
+        print(f"[DEBUG] time_in_hour range: {time_vals.min()} to {time_vals.max()}")
+        print(f"[DEBUG] time_in_hour count: {time_vals.nunique()}")
     
     return stage_merge_df, sw_transition_merge_df, stage_bout_merge_df
 
@@ -335,8 +343,21 @@ def merge_hourly_psd_ts_csv(dir):
     delta_columns = [col for col in frequency_columns if delta_range[0] <= float(col[2:]) <= delta_range[1]]
     theta_columns = [col for col in frequency_columns if theta_range[0] <= float(col[2:]) <= theta_range[1]]
     #csv読み込み、カラム名そろえる
-    df=pd.read_csv(os.path.join(dir,csv_fname)).rename(columns={"Experiment label":"exp_label","Mouse group":"mouse_group",
+    csv_path = os.path.join(dir, csv_fname)
+    if not os.path.exists(csv_path):
+        fallback_path = Path(dir).parents[1] / "PSD_raw" / csv_fname
+        if fallback_path.exists():
+            csv_path = str(fallback_path)
+        else:
+            print(f"[WARN] Missing hourly PSD CSV, skipping: {csv_path}")
+            return pd.DataFrame()
+    df=pd.read_csv(csv_path).rename(columns={"Experiment label":"exp_label","Mouse group":"mouse_group",
                                                                 "Mouse ID":"mouse_ID","Stage":"stage","hour":"time_in_hour"})
+    stats_path = Path(dir).parent / "stagetime_stats.npy"
+    if stats_path.exists():
+        stats = np.load(stats_path, allow_pickle=True)[()]
+        time_offset = stats.get("time_in_hour_offset", 0)
+        df["time_in_hour"] = df["time_in_hour"] + time_offset
     #nanを前後から補完
     for column in frequency_columns:
         #df[column] = df.groupby(['mouse_ID', 'stage'])[column].apply(lambda group: group.ffill().bfill().fillna(group.mean()))
@@ -377,27 +398,45 @@ def meta_merge_psd_csv(analyzed_dir_list, subdir_vehicle, subdir_rapalog):
     for dir in analyzed_dir_list:
         # Vehicle データの処理
         df_append_vehicle = merge_hourly_psd_ts_csv(os.path.join(dir, subdir_vehicle, "PSD_raw"))
-        df_append_vehicle = add_index(df_append_vehicle, "drug", "vehicle")
-        psd_ts_list.append(df_append_vehicle)  # リストに追加
+        if not df_append_vehicle.empty:
+            df_append_vehicle = add_index(df_append_vehicle, "drug", "vehicle")
+            psd_ts_list.append(df_append_vehicle)  # リストに追加
 
         # Rapalog データの処理
         df_append_rapalog = merge_hourly_psd_ts_csv(os.path.join(dir, subdir_rapalog, "PSD_raw"))
-        df_append_rapalog = add_index(df_append_rapalog, "drug", "rapalog")
-        psd_ts_list.append(df_append_rapalog)  # リストに追加
+        if not df_append_rapalog.empty:
+            df_append_rapalog = add_index(df_append_rapalog, "drug", "rapalog")
+            psd_ts_list.append(df_append_rapalog)  # リストに追加
 
         # Profile データの処理
         csv_fname = "PSD_norm_allday_percentage-profile.csv"
-        df_profile_append_vehicle = read_psd_profile_csv(os.path.join(dir, subdir_vehicle, "PSD_norm", csv_fname))
-        df_profile_append_vehicle = add_index(df_profile_append_vehicle, "drug", "vehicle")
-        psd_profile_list.append(df_profile_append_vehicle)  # リストに追加
+        vehicle_profile_path = os.path.join(dir, subdir_vehicle, "PSD_norm", csv_fname)
+        if not os.path.exists(vehicle_profile_path):
+            fallback_vehicle = Path(dir) / "PSD_norm" / csv_fname
+            if fallback_vehicle.exists():
+                vehicle_profile_path = str(fallback_vehicle)
+        if os.path.exists(vehicle_profile_path):
+            df_profile_append_vehicle = read_psd_profile_csv(vehicle_profile_path)
+            df_profile_append_vehicle = add_index(df_profile_append_vehicle, "drug", "vehicle")
+            psd_profile_list.append(df_profile_append_vehicle)  # リストに追加
+        else:
+            print(f"[WARN] Missing PSD profile CSV, skipping: {vehicle_profile_path}")
 
-        df_profile_append_rapalog = read_psd_profile_csv(os.path.join(dir, subdir_rapalog, "PSD_norm", csv_fname))
-        df_profile_append_rapalog = add_index(df_profile_append_rapalog, "drug", "rapalog")
-        psd_profile_list.append(df_profile_append_rapalog)  # リストに追加
+        rapalog_profile_path = os.path.join(dir, subdir_rapalog, "PSD_norm", csv_fname)
+        if not os.path.exists(rapalog_profile_path):
+            fallback_rapalog = Path(dir) / "PSD_norm" / csv_fname
+            if fallback_rapalog.exists():
+                rapalog_profile_path = str(fallback_rapalog)
+        if os.path.exists(rapalog_profile_path):
+            df_profile_append_rapalog = read_psd_profile_csv(rapalog_profile_path)
+            df_profile_append_rapalog = add_index(df_profile_append_rapalog, "drug", "rapalog")
+            psd_profile_list.append(df_profile_append_rapalog)  # リストに追加
+        else:
+            print(f"[WARN] Missing PSD profile CSV, skipping: {rapalog_profile_path}")
 
     # リスト内のデータフレームを結合
-    merge_psd_ts_df = pd.concat(psd_ts_list, ignore_index=False)  # 元のインデックスを保持
-    merge_psd_profile_df = pd.concat(psd_profile_list, ignore_index=False)  # 元のインデックスを保持
+    merge_psd_ts_df = pd.concat(psd_ts_list, ignore_index=False) if psd_ts_list else pd.DataFrame()
+    merge_psd_profile_df = pd.concat(psd_profile_list, ignore_index=False) if psd_profile_list else pd.DataFrame()
 
     return merge_psd_ts_df, merge_psd_profile_df
 
@@ -447,8 +486,15 @@ def process_stats_path_list(analyzed_dir_list,vehicle_path,rapalog_path):
     #vehicle_path="vehicle_84h_before_24h_after_60h/stagetime_stats.npy"
     #rapalog_path="rapalog_84h_before_24h_after_60h/stagetime_stats.npy"
     for dir in analyzed_dir_list:
-        stats_list_vehicle.append(os.path.join(dir,vehicle_path))
-        stats_list_rapalog.append(os.path.join(dir,rapalog_path))
+        vehicle_stats = os.path.join(dir, vehicle_path)
+        rapalog_stats = os.path.join(dir, rapalog_path)
+        fallback_stats = os.path.join(dir, "stagetime_stats.npy")
+        if not os.path.exists(vehicle_stats) and os.path.exists(fallback_stats):
+            vehicle_stats = fallback_stats
+        if not os.path.exists(rapalog_stats) and os.path.exists(fallback_stats):
+            rapalog_stats = fallback_stats
+        stats_list_vehicle.append(vehicle_stats)
+        stats_list_rapalog.append(rapalog_stats)
     return stats_list_vehicle,stats_list_rapalog
 
 def process_psd_info_path_list(analyzed_dir_list):
@@ -459,8 +505,15 @@ def process_psd_info_path_list(analyzed_dir_list):
     #vehicle_path="vehicle_84h_before_24h_after_60h/stagetime_stats.npy"
     #rapalog_path="rapalog_84h_before_24h_after_60h/stagetime_stats.npy"
     for dir in analyzed_dir_list:
-        psd_info_list_vehicle.append(os.path.join(dir,vehicle_path))
-        psd_info_list_rapalog.append(os.path.join(dir,rapalog_path))
+        vehicle_info = os.path.join(dir, vehicle_path)
+        rapalog_info = os.path.join(dir, rapalog_path)
+        fallback_info = os.path.join(dir, "psd_info_list.pkl")
+        if not os.path.exists(vehicle_info) and os.path.exists(fallback_info):
+            vehicle_info = fallback_info
+        if not os.path.exists(rapalog_info) and os.path.exists(fallback_info):
+            rapalog_info = fallback_info
+        psd_info_list_vehicle.append(vehicle_info)
+        psd_info_list_rapalog.append(rapalog_info)
     return psd_info_list_vehicle,psd_info_list_rapalog
 
 def merge_individual_df(analyzed_dir_list, vehicle_path, rapalog_path, epoch_len_sec, ample_freq):
@@ -474,6 +527,9 @@ def merge_individual_df(analyzed_dir_list, vehicle_path, rapalog_path, epoch_len
     
     # Vehicleデータの処理
     for stats in stats_list_vehicle:
+        if not os.path.exists(stats):
+            print(f"[WARN] Missing stats file, skipping: {stats}")
+            continue
         df, df2, df3 = make_df_from_summary_dic(stats)
         df = add_index(df, "drug", "vehicle")
         meta_merge_list.append(df)
@@ -483,12 +539,18 @@ def merge_individual_df(analyzed_dir_list, vehicle_path, rapalog_path, epoch_len
         meta_merge_list3.append(df3)
     
     for psd_info_list in psd_info_list_vehicle:
+        if not os.path.exists(psd_info_list):
+            print(f"[WARN] Missing PSD info file, skipping: {psd_info_list}")
+            continue
         df4 = extract_psd_from_psdinfo(psd_info_list, epoch_len_sec, ample_freq)
         df4 = add_index(df4, "drug", "vehicle")
         psd_start_n_end_list.append(df4)
     
     # Rapalogデータの処理
     for stats in stats_list_rapalog:
+        if not os.path.exists(stats):
+            print(f"[WARN] Missing stats file, skipping: {stats}")
+            continue
         df, df2, df3 = make_df_from_summary_dic(stats)
         df = add_index(df, "drug", "rapalog")
         meta_merge_list.append(df)
@@ -498,15 +560,22 @@ def merge_individual_df(analyzed_dir_list, vehicle_path, rapalog_path, epoch_len
         meta_merge_list3.append(df3)
     
     for psd_info_list in psd_info_list_rapalog:
+        if not os.path.exists(psd_info_list):
+            print(f"[WARN] Missing PSD info file, skipping: {psd_info_list}")
+            continue
         df4 = extract_psd_from_psdinfo(psd_info_list, epoch_len_sec, ample_freq)
         df4 = add_index(df4, "drug", "rapalog")
         psd_start_n_end_list.append(df4)
     
     # pd.concatでリスト内のデータフレームを結合
+    if not meta_merge_list:
+        print("[WARN] No stagetime stats were found for merging; skipping merge.")
+        empty_df = pd.DataFrame()
+        return empty_df, empty_df, empty_df, pd.DataFrame()
     meta_merge_df = pd.concat(meta_merge_list, ignore_index=False)
     meta_merge_df2 = pd.concat(meta_merge_list2, ignore_index=False)
     meta_merge_df3 = pd.concat(meta_merge_list3, ignore_index=False)
-    psd_start_n_end_df = pd.concat(psd_start_n_end_list, ignore_index=False)
+    psd_start_n_end_df = pd.concat(psd_start_n_end_list, ignore_index=False) if psd_start_n_end_list else pd.DataFrame()
     
     return meta_merge_df, meta_merge_df2, meta_merge_df3, psd_start_n_end_df
 
@@ -585,10 +654,13 @@ def group_analysis_each_df(df: pd.DataFrame):
 
     return mean, sem, count
 
-def extract_mean_n_err(mean,sem,g_name,drug,sleep_stage,val_name):
-    y=np.array(mean.loc[pd.IndexSlice[g_name,drug,sleep_stage,:],val_name]).flatten()
-    err=np.array(sem.loc[pd.IndexSlice[g_name,drug,sleep_stage,:],val_name]).flatten()
-    return y,err
+def extract_mean_n_err(mean, sem, g_name, drug, sleep_stage, val_name):
+    subset = mean.loc[pd.IndexSlice[g_name, drug, sleep_stage, :], val_name]
+    subset = subset.sort_index()
+    x = subset.index.get_level_values("time_in_hour").to_numpy()
+    y = subset.to_numpy()
+    err = sem.loc[subset.index, val_name].to_numpy()
+    return x, y, err
 
 def extract_mean_n_err_for_PSD(mean,sem,g_name,drug,sleep_stage):
     freq_bins=sp.psd_freq_bins(sample_freq=128)
@@ -598,22 +670,26 @@ def extract_mean_n_err_for_PSD(mean,sem,g_name,drug,sleep_stage):
     return y,err
 
 def plot_ts_1group(mean,sem,count,g_name,sleep_stage,ax1,val_name,y_label):
-    x_val=np.arange(0,24)
     dark_period=[[0,12],[24,36],[48,60]]
     light_period=[[12,24],[36,48]]
     
-    y,err=extract_mean_n_err(mean,sem,g_name,"vehicle",sleep_stage,val_name)
+    x_val, y, err=extract_mean_n_err(mean,sem,g_name,"vehicle",sleep_stage,val_name)
     sample_n=count.loc[pd.IndexSlice[g_name,"vehicle",sleep_stage,0]][0]
     #label_str="vehicle (n=%d)"%sample_n
     label_str="vehicle"
     plot_timeseries(ax1,x_val,y,err,"k",label_str)
 
-    y,err=extract_mean_n_err(mean,sem,g_name,"rapalog",sleep_stage,val_name)
+    x_min = float(np.min(x_val)) if x_val.size else 0
+    x_max = float(np.max(x_val)) if x_val.size else 0
+    x_val, y, err=extract_mean_n_err(mean,sem,g_name,"rapalog",sleep_stage,val_name)
     sample_n=count.loc[pd.IndexSlice[g_name,"rapalog",sleep_stage,0]][0]
     #label_str="rapalog (n=%d)"%sample_n
     label_str="rapalog"
     plot_timeseries(ax1,x_val,y,err,"r",label_str)
     
+    if x_val.size:
+        x_min = min(x_min, float(np.min(x_val)))
+        x_max = max(x_max, float(np.max(x_val)))
     for ax in [ax1]:
         ax.plot([0,60],[0.1,0.1],linewidth=5,color="yellow")
         ax.plot([6.5,17.5],[0.1,0.1],linewidth=5,color="k")
@@ -662,11 +738,12 @@ def plot_ts_1group(mean,sem,count,g_name,sleep_stage,ax1,val_name,y_label):
             ax.set_yticks([0,20,40,60])
         #ax.set_ylabel("NREM sleep duration (min/h)")
         ax.set_ylabel(y_label)
-        ax.set_xticks([0,6,12,18,24])
-        ax.set_xticklabels([-6,0,6,12,18])
-        ax.plot([6,6],[0,ax.get_ylim()[1]],"--",color="gray")
-        ax.set_xlabel("Time after ip (h)")
-        ax.set_xlim([0,24])
+        xticks = np.arange(x_min, x_max + 1, 6) if x_max != x_min else [x_min]
+        ax.set_xticks(xticks)
+        ax.set_xticklabels([int(x) for x in xticks])
+        ax.plot([0, 0], [0, ax.get_ylim()[1]], "--", color="gray")
+        ax.set_xlabel("Time relative to injection (h)")
+        ax.set_xlim([x_min, x_max])
         ax.spines['right'].set_visible(False)
         ax.spines['top'].set_visible(False)
         ax.legend(fontsize=10,frameon=False)
@@ -674,13 +751,14 @@ def plot_ts_1group(mean,sem,count,g_name,sleep_stage,ax1,val_name,y_label):
 
 
 def plot_ts_mouse_groups(mean, sem, count, mouse_groups, drug, sleep_stage, ax1, val_name, y_label):
-    x_val = np.arange(0, 24)
     palette = sns.color_palette("colorblind", n_colors=len(mouse_groups))
 
     plotted_any = False
+    x_min = 0
+    x_max = 0
     for g_name, color in zip(mouse_groups, palette):
         try:
-            y, err = extract_mean_n_err(mean, sem, g_name, drug, sleep_stage, val_name)
+            x_val, y, err = extract_mean_n_err(mean, sem, g_name, drug, sleep_stage, val_name)
             sample_n = count.loc[pd.IndexSlice[g_name, drug, sleep_stage, 0]][0]
         except KeyError:
             print(f"[WARN] plot_ts_mouse_groups: data missing for group={g_name}, drug={drug}, stage={sleep_stage}")
@@ -688,6 +766,9 @@ def plot_ts_mouse_groups(mean, sem, count, mouse_groups, drug, sleep_stage, ax1,
 
         plot_timeseries(ax1, x_val, y, err, color, g_name)
         plotted_any = True
+        if x_val.size:
+            x_min = min(x_min, float(np.min(x_val)))
+            x_max = max(x_max, float(np.max(x_val)))
 
     if not plotted_any:
         print(f"[WARN] plot_ts_mouse_groups: no data plotted for drug={drug}, stage={sleep_stage}")
@@ -740,11 +821,12 @@ def plot_ts_mouse_groups(mean, sem, count, mouse_groups, drug, sleep_stage, ax1,
             ax.set_ylim([0,60])
             ax.set_yticks([0,20,40,60])
         ax.set_ylabel(y_label)
-        ax.set_xticks([0,6,12,18,24])
-        ax.set_xticklabels([-6,0,6,12,18])
-        ax.plot([6,6],[0,ax.get_ylim()[1]],"--",color="gray")
-        ax.set_xlabel("Time after ip (h)")
-        ax.set_xlim([0,24])
+        xticks = np.arange(x_min, x_max + 1, 6) if x_max != x_min else [x_min]
+        ax.set_xticks(xticks)
+        ax.set_xticklabels([int(x) for x in xticks])
+        ax.plot([0, 0], [0, ax.get_ylim()[1]], "--", color="gray")
+        ax.set_xlabel("Time relative to injection (h)")
+        ax.set_xlim([x_min, x_max])
         ax.spines['right'].set_visible(False)
         ax.spines['top'].set_visible(False)
         ax.legend(fontsize=10,frameon=False)
@@ -1024,6 +1106,20 @@ def plot_bargraph_mouse_groups(df, mouse_groups, drug, sleep_stage, y_value, y_l
         hue="mouse_group",
         palette=palette,
         dodge=False,
+        legend=False,
+        ax=ax,
+    )
+
+    sns.stripplot(
+        data=sub,
+        x="mouse_group",
+        y=y_value,
+        hue="mouse_group",
+        palette=palette,
+        dodge=False,
+        jitter=True,
+        alpha=0.6,
+        size=4,
         legend=False,
         ax=ax,
     )
@@ -1309,6 +1405,14 @@ def merge_n_plot(
 
     #merge analyzed data
     meta_stage_df,meta_sw_trans_df,meta_stage_bout_df,meta_psd_start_end_df=merge_sleep_stage_df(analyzed_dir_list,epoch_len_sec,sample_freq)
+    if meta_stage_df.empty:
+        print("[WARN] No merged stagetime data available; skipping plot generation.")
+        return {
+            "meta_stage_df": meta_stage_df,
+            "meta_sw_trans_df": meta_sw_trans_df,
+            "meta_stage_bout_df": meta_stage_bout_df,
+            "meta_psd_start_end_df": meta_psd_start_end_df,
+        }
     merge_psd_ts_df,merge_psd_profile_df=merge_psd_df(analyzed_dir_list)
     
     #rename group if needed
@@ -1673,8 +1777,18 @@ def wilcoxon_n_paried_t(stage_df,psd_df,bout_df,target_group,stage):
     data1=stage_df[(stage_df.mouse_group==target_group)&(stage_df.stage==stage)&(stage_df.drug=="vehicle")].min_per_hour
     data2=stage_df[(stage_df.mouse_group==target_group)&(stage_df.stage==stage)&(stage_df.drug=="rapalog")].min_per_hour
     from scipy.stats import wilcoxon
+    def safe_wilcoxon(a, b, label):
+        a = np.asarray(a)
+        b = np.asarray(b)
+        if a.size == 0 or b.size == 0:
+            print(f"wilcoxon skipped for {label}: empty data")
+            return None, None
+        if np.allclose(a - b, 0, equal_nan=True):
+            print(f"wilcoxon skipped for {label}: all differences are zero")
+            return None, None
+        return wilcoxon(a, b)
     # ウィルコクソンの符号順位検定
-    statistic, p_value = wilcoxon(data1, data2)
+    statistic, p_value = safe_wilcoxon(data1, data2, "stage duration")
     print("wilcoxon")
     print('Statistic:', statistic)
     print('p-value:', p_value)
@@ -1690,7 +1804,7 @@ def wilcoxon_n_paried_t(stage_df,psd_df,bout_df,target_group,stage):
     data2=bout_df[(bout_df.mouse_group==target_group)&(bout_df.stage==stage)&(bout_df.drug=="rapalog")].bout_count
     
     # ウィルコクソンの符号順位検定
-    statistic, p_value = wilcoxon(data1, data2)
+    statistic, p_value = safe_wilcoxon(data1, data2, "stage bout count")
     print("wilcoxon")
     print('Statistic:', statistic)
     print('p-value:', p_value)
@@ -1700,7 +1814,7 @@ def wilcoxon_n_paried_t(stage_df,psd_df,bout_df,target_group,stage):
     data2=bout_df[(bout_df.mouse_group==target_group)&(bout_df.stage==stage)&(bout_df.drug=="rapalog")].mean_duration_sec
 
     # ウィルコクソンの符号順位検定
-    statistic, p_value = wilcoxon(data1, data2)
+    statistic, p_value = safe_wilcoxon(data1, data2, "stage bout length")
     print("wilcoxon")
     print('Statistic:', statistic)
     print('p-value:', p_value)
@@ -1710,7 +1824,7 @@ def wilcoxon_n_paried_t(stage_df,psd_df,bout_df,target_group,stage):
     data2=psd_df[(psd_df.mouse_group==target_group)&(psd_df.stage==stage)&(psd_df.drug=="rapalog")].delta_power
 
     # ウィルコクソンの符号順位検定
-    statistic, p_value = wilcoxon(data1, data2)
+    statistic, p_value = safe_wilcoxon(data1, data2, "norm delta power")
     print("wilcoxon")
     print('Statistic:', statistic)
     print('p-value:', p_value)
@@ -1727,7 +1841,7 @@ def wilcoxon_n_paried_t(stage_df,psd_df,bout_df,target_group,stage):
     data2=psd_df[(psd_df.mouse_group==target_group)&(psd_df.stage==stage)&(psd_df.drug=="rapalog")].theta_power
 
     # ウィルコクソンの符号順位検定
-    statistic, p_value = wilcoxon(data1, data2)
+    statistic, p_value = safe_wilcoxon(data1, data2, "norm theta power")
     print("wilcoxon")
     print('Statistic:', statistic)
     print('p-value:', p_value)

--- a/faster2lib/summary_psd.py
+++ b/faster2lib/summary_psd.py
@@ -4,6 +4,7 @@
 from logging import getLogger
 from matplotlib.figure import Figure
 import os
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import faster2lib.eeg_tools as et
@@ -69,11 +70,19 @@ def make_psd_profile(psd_info_list, sample_freq, epoch_len_sec, psd_type='norm',
 
         # Default mask
         if mask is None:
-            mask = np.full(len(psd_info['bidx_target']), True)
+            current_mask = np.full(len(psd_info['bidx_target']), True)
+        else:
+            current_len = len(psd_info['bidx_target'])
+            if len(mask) >= current_len:
+                current_mask = mask[:current_len]
+            else:
+                current_mask = np.concatenate(
+                    [mask, np.full(current_len - len(mask), False)]
+                )
 
-        bidx_rem_target = psd_info['bidx_rem'] & psd_info['bidx_target'] & mask
-        bidx_nrem_target = psd_info['bidx_nrem'] & psd_info['bidx_target'] & mask
-        bidx_wake_target = psd_info['bidx_wake'] & psd_info['bidx_target'] & mask
+        bidx_rem_target = psd_info['bidx_rem'] & psd_info['bidx_target'] & current_mask
+        bidx_nrem_target = psd_info['bidx_nrem'] & psd_info['bidx_target'] & current_mask
+        bidx_wake_target = psd_info['bidx_wake'] & psd_info['bidx_target'] & current_mask
 
         psd_summary_rem = _psd_summary_by_bidx(bidx_rem_target)
         psd_summary_nrem = _psd_summary_by_bidx(bidx_nrem_target)
@@ -95,9 +104,9 @@ def make_psd_profile(psd_info_list, sample_freq, epoch_len_sec, psd_type='norm',
                 hour_mask = np.zeros(total_epochs, dtype=bool)
                 hour_mask[hour * epochs_per_hour:(hour + 1) * epochs_per_hour] = True
 
-                bidx_rem_hourly = (psd_info['stage_call'] == "REM") & mask & hour_mask
-                bidx_nrem_hourly = (psd_info['stage_call'] == "NREM") & mask & hour_mask
-                bidx_wake_hourly = (psd_info['stage_call'] == "WAKE") & mask & hour_mask
+                bidx_rem_hourly = (psd_info['stage_call'] == "REM") & current_mask & hour_mask
+                bidx_nrem_hourly = (psd_info['stage_call'] == "NREM") & current_mask & hour_mask
+                bidx_wake_hourly = (psd_info['stage_call'] == "WAKE") & current_mask & hour_mask
 
                 psd_summary_rem_hourly = _psd_summary_by_bidx(bidx_rem_hourly)
                 psd_summary_nrem_hourly = _psd_summary_by_bidx(bidx_nrem_hourly)
@@ -121,9 +130,20 @@ def make_psd_profile(psd_info_list, sample_freq, epoch_len_sec, psd_type='norm',
         hourly_psd_summary_df = pd.DataFrame(hourly_rows, columns=hourly_columns)
 
         # Fill missing values by interpolation
-        hourly_psd_summary_df = hourly_psd_summary_df.groupby(['Mouse ID', 'Stage']).apply(
-            lambda group: group.interpolate(method='linear', limit_direction='both')
-        ).reset_index(drop=True)
+        def _interpolate_numeric(group: pd.DataFrame) -> pd.DataFrame:
+            group = group.infer_objects(copy=False)
+            numeric_cols = group.select_dtypes(include=[np.number]).columns
+            group[numeric_cols] = group[numeric_cols].interpolate(
+                method='linear',
+                limit_direction='both',
+            )
+            return group
+
+        hourly_psd_summary_df = (
+            hourly_psd_summary_df.groupby(['Mouse ID', 'Stage'])
+            .apply(_interpolate_numeric)
+            .reset_index(drop=True)
+        )
 
         return psd_summary_df, hourly_psd_summary_df
     else:
@@ -168,14 +188,17 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
 
 
         # read stage of the mouse
+        result_dir = Path(faster_dir)
+        if result_dir.name != result_dir_name:
+            result_dir = result_dir / result_dir_name
+        result_dir = str(result_dir)
         try:
-            stage_call, nan_eeg, outlier_eeg = et.read_stages_with_eeg_diagnosis(os.path.join(
-                faster_dir, result_dir_name), device_label, stage_ext)
+            stage_call, nan_eeg, outlier_eeg = et.read_stages_with_eeg_diagnosis(
+                result_dir, device_label, stage_ext)
         except IndexError:
             # Manually annotated stage files may not have diagnostic info
             LOGGER.info('NA and outlier information is not available in the stage file')
-            stage_call = et.read_stages(os.path.join(
-                faster_dir, result_dir_name), device_label, stage_ext)
+            stage_call = et.read_stages(result_dir, device_label, stage_ext)
             nan_eeg = np.repeat(0, len(stage_call))
             outlier_eeg = np.repeat(0, len(stage_call))
         epoch_num = len(stage_call)
@@ -186,8 +209,7 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
         #    os.path.join(faster_dir, 'data'), device_label, sample_freq, epoch_len_sec,
         #    epoch_num, start_datetime)
         (eeg_vm_org, emg_vm_org, not_yet_pickled) = stage.read_voltage_matrices(
-            os.path.join(faster_dir, result_dir_name), device_label, sample_freq, epoch_len_sec,
-            epoch_num, start_datetime)
+            result_dir, device_label, sample_freq, epoch_len_sec, epoch_num, start_datetime)
 
 
         LOGGER.info('Preprocessing and calculating PSD')
@@ -213,20 +235,42 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
         # good PSD should have the nan- and outlier-ratios of less than 1%
         bidx_good_psd = (nan_eeg < 0.01) & (outlier_eeg < 0.01)
 
+        if isinstance(epoch_range, range):
+            epoch_end = min(epoch_range.stop, epoch_num)
+            effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+        elif isinstance(epoch_range, slice):
+            stop = epoch_range.stop if epoch_range.stop is not None else epoch_num
+            effective_epoch_range = slice(epoch_range.start, min(stop, epoch_num), epoch_range.step)
+        else:
+            effective_epoch_range = [idx for idx in epoch_range if idx < epoch_num]
+
         # bidx_target: bidx for the good epochs in the selected range
         bidx_selected = np.repeat(False, epoch_num)
-        bidx_selected[epoch_range] = True
+        bidx_selected[effective_epoch_range] = True
         bidx_target = bidx_selected & bidx_good_psd & ~bidx_unknown
+
+        if isinstance(effective_epoch_range, range):
+            range_start = effective_epoch_range.start
+            range_stop = effective_epoch_range.stop
+            range_len = range_stop - range_start
+        elif isinstance(effective_epoch_range, slice):
+            range_start = effective_epoch_range.start or 0
+            range_stop = effective_epoch_range.stop or epoch_num
+            range_len = len(range(range_start, range_stop, effective_epoch_range.step or 1))
+        else:
+            range_start = min(effective_epoch_range) if effective_epoch_range else 0
+            range_stop = (max(effective_epoch_range) + 1) if effective_epoch_range else 0
+            range_len = len(effective_epoch_range)
+        selected_count = np.sum(bidx_selected)
 
         LOGGER.info('    Target epoch range: %d-%d (%d epochs out of %d epochs)\n'\
                     '    Unknown epochs in the range: %d (%.3f %%)\n'\
                     '    Outlier or NA epochs in the range: %d (%.3f %%)',
-                    epoch_range.start, epoch_range.stop,
-                    epoch_range.stop - epoch_range.start, epoch_num,
+                    range_start, range_stop, range_len, epoch_num,
                     np.sum(bidx_unknown & bidx_selected), 100 *
-                    np.sum(bidx_unknown & bidx_selected)/np.sum(bidx_selected),
+                    np.sum(bidx_unknown & bidx_selected)/max(selected_count, 1),
                     np.sum(~bidx_good_psd & bidx_selected),
-                    100*np.sum(~bidx_good_psd & bidx_selected)/np.sum(bidx_selected))
+                    100*np.sum(~bidx_good_psd & bidx_selected)/max(selected_count, 1))
 
 
         bidx_rem = (stage_call == 'REM') & bidx_target
@@ -262,14 +306,14 @@ def make_target_psd_info(mouse_info_df, epoch_range, epoch_len_sec, sample_freq,
                               'mouse_group': mouse_group,
                               'mouse_id': mouse_id,
                               'device_label': device_label,
-                              'stage_call': stage_call[epoch_range],
-                              'bidx_rem': bidx_rem[epoch_range],
-                              'bidx_nrem': bidx_nrem[epoch_range],
-                              'bidx_wake': bidx_wake[epoch_range],
-                              'bidx_unknown': bidx_unknown[epoch_range],
-                              'bidx_target': bidx_target[epoch_range],
-                              'norm': conv_psd[epoch_range],
-                              'raw': conv_psd_raw[epoch_range]})
+                              'stage_call': stage_call[effective_epoch_range],
+                              'bidx_rem': bidx_rem[effective_epoch_range],
+                              'bidx_nrem': bidx_nrem[effective_epoch_range],
+                              'bidx_wake': bidx_wake[effective_epoch_range],
+                              'bidx_unknown': bidx_unknown[effective_epoch_range],
+                              'bidx_target': bidx_target[effective_epoch_range],
+                              'norm': conv_psd[effective_epoch_range],
+                              'raw': conv_psd_raw[effective_epoch_range]})
 
     return psd_info_list
 
@@ -345,7 +389,7 @@ def make_psd_stats(psd_domain_df):
 
     # Initialize the DataFrame columns
     columns = ['Mouse group', 'Stage type', 'Wave type', 'N', 'Mean', 'SD', 'Pvalue', 'Stars', 'Method']
-    psd_stats_df = pd.DataFrame(columns=columns)
+    psd_stats_frames = []
 
     # Mouse group setup
     mouse_group_list = psd_domain_df['Mouse group'].tolist()
@@ -370,7 +414,8 @@ def make_psd_stats(psd_domain_df):
 
     # Add control group rows to DataFrame
     control_rows_df = pd.DataFrame(rows, columns=columns)
-    psd_stats_df = pd.concat([psd_stats_df, control_rows_df], ignore_index=True)
+    if not control_rows_df.empty:
+        psd_stats_frames.append(control_rows_df)
 
     # Treatment groups
     for group_t in mouse_group_set[1:]:
@@ -390,7 +435,13 @@ def make_psd_stats(psd_domain_df):
 
         # Add treatment group rows to DataFrame
         treatment_rows_df = pd.DataFrame(rows, columns=columns)
-        psd_stats_df = pd.concat([psd_stats_df, treatment_rows_df], ignore_index=True)
+        if not treatment_rows_df.empty:
+            psd_stats_frames.append(treatment_rows_df)
+
+    if psd_stats_frames:
+        psd_stats_df = pd.concat(psd_stats_frames, ignore_index=True)
+    else:
+        psd_stats_df = pd.DataFrame(columns=columns)
 
     return psd_stats_df
 
@@ -407,6 +458,27 @@ def make_psd_timeseries_df(psd_info_list, epoch_range, bidx_freq, stage_bidx_key
     Returns:
         [pd.dataframe]: The timeseries of PSD
     """
+    if not psd_info_list:
+        return pd.DataFrame()
+    min_epoch_num = min(len(psd_info['bidx_target']) for psd_info in psd_info_list)
+    if isinstance(epoch_range, range):
+        epoch_end = min(epoch_range.stop, min_epoch_num)
+        effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+    elif isinstance(epoch_range, slice):
+        stop = epoch_range.stop if epoch_range.stop is not None else min_epoch_num
+        effective_epoch_range = slice(epoch_range.start, min(stop, min_epoch_num), epoch_range.step)
+    else:
+        effective_epoch_range = [idx for idx in epoch_range if idx < min_epoch_num]
+
+    if isinstance(effective_epoch_range, range):
+        range_len = effective_epoch_range.stop - effective_epoch_range.start
+    elif isinstance(effective_epoch_range, slice):
+        range_len = len(range(effective_epoch_range.start or 0,
+                              effective_epoch_range.stop or min_epoch_num,
+                              effective_epoch_range.step or 1))
+    else:
+        range_len = len(effective_epoch_range)
+
     psd_timeseries_df = pd.DataFrame()
     for psd_info in psd_info_list:
         bidx_target = psd_info['bidx_target']
@@ -417,8 +489,9 @@ def make_psd_timeseries_df(psd_info_list, epoch_range, bidx_freq, stage_bidx_key
             bidx_targeted_stage = bidx_target
 
         conv_psd = psd_info[psd_type]
-        psd_delta_timeseries = np.repeat(np.nan, epoch_range.stop - epoch_range.start)
-        psd_delta_timeseries[bidx_targeted_stage[epoch_range]] = np.apply_along_axis(np.nanmean, 1, conv_psd[bidx_targeted_stage, :][:,bidx_freq])
+        psd_delta_timeseries = np.repeat(np.nan, range_len)
+        psd_delta_timeseries[bidx_targeted_stage[effective_epoch_range]] = np.apply_along_axis(
+            np.nanmean, 1, conv_psd[bidx_targeted_stage, :][:, bidx_freq])
         #psd_timeseries_df = psd_timeseries_df.append(
         #    [[psd_info['exp_label'], psd_info['mouse_group'], psd_info['mouse_id'], psd_info['device_label']] + psd_delta_timeseries.tolist()], ignore_index=True)
         # 新しい行データを準備
@@ -429,7 +502,16 @@ def make_psd_timeseries_df(psd_info_list, epoch_range, bidx_freq, stage_bidx_key
 
         # pd.concatを使用してDataFrameを更新
         psd_timeseries_df = pd.concat([psd_timeseries_df, new_row], ignore_index=True)
-    epoch_columns = [f'epoch{x+1}' for x in np.arange(epoch_range.start, epoch_range.stop)]
+    if isinstance(effective_epoch_range, range):
+        epoch_indices = np.arange(effective_epoch_range.start, effective_epoch_range.stop,
+                                  effective_epoch_range.step)
+    elif isinstance(effective_epoch_range, slice):
+        epoch_indices = np.arange(effective_epoch_range.start or 0,
+                                  effective_epoch_range.stop or min_epoch_num,
+                                  effective_epoch_range.step or 1)
+    else:
+        epoch_indices = np.array(effective_epoch_range)
+    epoch_columns = [f'epoch{x+1}' for x in epoch_indices]
     column_names = ['Experiment label', 'Mouse group', 'Mouse ID', 'Device label'] + epoch_columns
     psd_timeseries_df.columns = column_names
 

--- a/pipeline_step2_analyze.py
+++ b/pipeline_step2_analyze.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pathlib import Path
+from typing import Optional, Tuple
 import pandas as pd
 import os
 import numpy as np
@@ -90,9 +91,18 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
     epoch_num_stored = None
     sample_freq_stored = None
     for faster_dir in faster_dir_list:
-        data_dir = os.path.join(faster_dir, 'data')
+        data_dir = Path(faster_dir) / "data"
+        if not (data_dir / "exp.info.csv").exists():
+            sibling_data_dir = Path(faster_dir).parent / "data"
+            if (sibling_data_dir / "exp.info.csv").exists():
+                data_dir = sibling_data_dir
+            else:
+                raise FileNotFoundError(
+                    "exp.info.csv was not found under expected data directories. "
+                    f"Tried: {data_dir / 'exp.info.csv'} and {sibling_data_dir / 'exp.info.csv'}"
+                )
 
-        exp_info_df = stage.read_exp_info(data_dir)
+        exp_info_df = stage.read_exp_info(str(data_dir))
         # not used variable: rack_label, start_datetime, end_datetime
         # pylint: disable=unused-variable
         (epoch_num, sample_freq, exp_label, rack_label, \
@@ -106,11 +116,59 @@ def collect_mouse_info_df(faster_dir_list, epoch_len_sec):
         else:
             sample_freq_stored = sample_freq
 
-        m_info = stage.read_mouse_info(data_dir)
+        m_info = stage.read_mouse_info(str(data_dir))
         m_info['Experiment label'] = exp_label
         m_info['FASTER_DIR'] = faster_dir
         mouse_info_df = pd.concat([mouse_info_df, m_info])
     return ({'mouse_info': mouse_info_df, 'epoch_num': epoch_num, 'sample_freq': sample_freq, 'start_datetime': start_datetime})
+
+
+def resolve_data_dir(faster_dir: str) -> Path:
+    data_dir = Path(faster_dir) / "data"
+    if not (data_dir / "exp.info.csv").exists():
+        sibling_data_dir = Path(faster_dir).parent / "data"
+        if (sibling_data_dir / "exp.info.csv").exists():
+            data_dir = sibling_data_dir
+        else:
+            raise FileNotFoundError(
+                "exp.info.csv was not found under expected data directories. "
+                f"Tried: {data_dir / 'exp.info.csv'} and {sibling_data_dir / 'exp.info.csv'}"
+            )
+    return data_dir
+
+
+def read_drug_info(data_dir: Path, exp_label: str) -> dict:
+    drug_info_path = data_dir / "drug.info.csv"
+    if not drug_info_path.exists():
+        return {}
+    drug_info_df = pd.read_csv(drug_info_path, parse_dates=["drug1_datetime", "drug2_datetime"])
+    row = drug_info_df.loc[drug_info_df["Experiment label"] == exp_label]
+    if row.empty:
+        return {}
+    row = row.iloc[0]
+    drug_map = {}
+    for idx in (1, 2):
+        name_col = f"drug{idx}_name"
+        datetime_col = f"drug{idx}_datetime"
+        if name_col not in row or datetime_col not in row:
+            continue
+        name = str(row[name_col]).strip().lower()
+        if not name or name == "nan":
+            continue
+        dt_raw = row[datetime_col]
+        if pd.isna(dt_raw):
+            continue
+        drug_map[name] = dt_raw
+    return drug_map
+
+
+def format_injection_subdir(drug_name: str, before_hours: float, after_hours: float) -> str:
+    def _format_hours(value: float) -> str:
+        if float(value).is_integer():
+            return str(int(value))
+        return str(value).replace(".", "p")
+
+    return f"{drug_name}_{_format_hours(before_hours)}h_before{_format_hours(after_hours)}h"
 def stagetime_in_a_day(stage_call):
     """Count each stage in the stage_call list and calculate
     the daily stage time in minuites.
@@ -145,9 +203,15 @@ def stagetime_profile(stage_call, epoch_len_sec):
         [np.array(3, len(stage_calls))] -- each row corrensponds the
         hourly profiles of stages over the recording (rem, nrem, wake)
     """
-    print(stage_call.shape)
-    sm = stage_call.reshape(-1, int(3600/epoch_len_sec)
-                            )  # 60 min(3600 sec) bin
+    bin_size = int(3600 / epoch_len_sec)
+    usable_len = (len(stage_call) // bin_size) * bin_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one hour; skipping profile.")
+        return np.zeros((3, 0))
+    if usable_len != len(stage_call):
+        print_log(f"Trimming stage calls to {usable_len} for hourly profile.")
+        stage_call = stage_call[:usable_len]
+    sm = stage_call.reshape(-1, bin_size)  # 60 min(3600 sec) bin
     rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
                     60 for s in sm])  # unit minuite
     nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
@@ -171,8 +235,16 @@ def stagetime_circadian_profile(stage_call, epoch_len_sec):
                             x 3rd axis [24 hours]
     """
     # 60 min(3600 sec) bin
-    print(stage_call.shape)
-    sm = stage_call.reshape(-1, int(3600/epoch_len_sec))
+    bin_size = int(3600 / epoch_len_sec)
+    day_size = bin_size * 24
+    usable_len = (len(stage_call) // day_size) * day_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one day; skipping circadian profile.")
+        return np.zeros((2, 3, 0))
+    if usable_len != len(stage_call):
+        print_log(f"Trimming stage calls to {usable_len} for circadian profile.")
+        stage_call = stage_call[:usable_len]
+    sm = stage_call.reshape(-1, bin_size)
     rem = np.array([np.sum(s == 'REM')*epoch_len_sec /
                     60 for s in sm])  # unit minuite
     nrem = np.array([np.sum(s == 'NREM')*epoch_len_sec /
@@ -244,8 +316,9 @@ def hourly_bout_profile(bout_df, epoch_len_sec):
 
     # 元のデータフレームと結合し、欠けている組み合わせを補完
     bout_profile_df = pd.merge(complete_df, bout_profile_df, on=['hour', 'stage'], how='left')
-    bout_profile_df['bout_count'].fillna(0, inplace=True)
-    bout_profile_df['mean_duration_sec'].fillna(0, inplace=True)
+    bout_profile_df[['bout_count', 'mean_duration_sec']] = (
+        bout_profile_df[['bout_count', 'mean_duration_sec']].fillna(0)
+    )
     
     return bout_profile_df
 
@@ -455,10 +528,22 @@ def swtrans_profile(stage_call, epoch_len_sec):
     tws = np.append(tws, 0)
     tww = np.append(tww, 0)
 
-    tsw_mat = tsw.reshape(-1, int(3600/epoch_len_sec))  # 60 min(3600 sec) bin
-    tss_mat = tss.reshape(-1, int(3600/epoch_len_sec))
-    tws_mat = tws.reshape(-1, int(3600/epoch_len_sec))
-    tww_mat = tww.reshape(-1, int(3600/epoch_len_sec))
+    bin_size = int(3600 / epoch_len_sec)
+    usable_len = (len(tsw) // bin_size) * bin_size
+    if usable_len == 0:
+        print_log("Stage call length is shorter than one hour; skipping swtrans profile.")
+        return [np.array([]), np.array([])]
+    if usable_len != len(tsw):
+        print_log(f"Trimming stage calls to {usable_len} for swtrans profile.")
+        tsw = tsw[:usable_len]
+        tss = tss[:usable_len]
+        tws = tws[:usable_len]
+        tww = tww[:usable_len]
+
+    tsw_mat = tsw.reshape(-1, bin_size)  # 60 min(3600 sec) bin
+    tss_mat = tss.reshape(-1, bin_size)
+    tws_mat = tws.reshape(-1, bin_size)
+    tww_mat = tww.reshape(-1, bin_size)
 
     hourly_tsw = np.apply_along_axis(np.sum, 1, tsw_mat) 
     hourly_tss = np.apply_along_axis(np.sum, 1, tss_mat) 
@@ -580,10 +665,9 @@ def _set_common_features_stagetime_profile_rem(ax, x_max):
 def draw_stagetime_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
     stagetime_df = stagetime_stats['stagetime']
     stagetime_profile_list = stagetime_stats['stagetime_profile']
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
-    x = np.arange(x_max)
     for i, profile in enumerate(stagetime_profile_list):
+        x_max = profile.shape[1]
+        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
@@ -627,8 +711,7 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
             np.std, 0, stagetime_profile_mat[bidx])
         stagetime_profile_stats_list.append(
             np.array([stagetime_profile_mean, stagetime_profile_sd]))
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
+    x_max = stagetime_profile_mat.shape[-1]
     x = np.arange(x_max)
     if len(mouse_groups_set) > 1:
         # contrast to group index = 0
@@ -719,8 +802,6 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
         csv_df = pd.DataFrame()
         mgs_t = mouse_groups_set[g_idx] # treatment
         num = np.sum(bidx_group_list[g_idx])
-        x_max = epoch_num*epoch_len_sec/3600
-        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(311, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(312, xmargin=0, ymargin=0)
@@ -769,10 +850,10 @@ def draw_stagetime_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
 def draw_swtrans_profile_individual(stagetime_stats, epoch_len_sec, output_dir):
     stagetime_df = stagetime_stats['stagetime']
     swtrans_profile_list = stagetime_stats['swtrans_profile']
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
-    x = np.arange(x_max)
     for i, profile in enumerate(swtrans_profile_list):
+        profile = np.asarray(profile)
+        x_max = profile.shape[1]
+        x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
         ax2 = fig.add_subplot(212, xmargin=0, ymargin=0)
@@ -815,8 +896,7 @@ def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
                 np.nanstd, 0, swtrans_profile_mat[bidx])
             swtrans_profile_stats_list.append(
                 np.array([swtrans_profile_mean, swtrans_profile_sd]))
-    epoch_num = stagetime_stats['epoch_num_in_range']
-    x_max = epoch_num*epoch_len_sec/3600
+    x_max = swtrans_profile_mat.shape[-1]
     x = np.arange(x_max)
     if len(mouse_groups_set) > 1:
         # contrast to group index = 0
@@ -873,7 +953,7 @@ def draw_swtrans_profile_grouped(stagetime_stats, epoch_len_sec, output_dir):
         g_idx = 0
 
         num = np.sum(bidx_group_list[g_idx])
-        x_max = epoch_num*epoch_len_sec/3600
+        x_max = swtrans_profile_mat.shape[-1]
         x = np.arange(x_max)
         fig = Figure(figsize=(13, 6))
         ax1 = fig.add_subplot(211, xmargin=0, ymargin=0)
@@ -2194,15 +2274,31 @@ def make_psd_output_dirs(output_dir, psd_type):
     output_dir = os.path.join(output_dir, f'PSD_{psd_type}')
     os.makedirs(os.path.join(output_dir, 'pdf'), exist_ok=True)
     
+def resolve_result_dir(faster_dir, result_dir_name):
+    result_dir = Path(faster_dir)
+    if result_dir.name != result_dir_name:
+        result_dir = result_dir / result_dir_name
+    return result_dir
+
+
 def extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range):
     print("extract_EEG_n_EMG")
-    EEG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EEG.pkl"))
-    EMG_raw=pd.read_pickle(os.path.join(faster_dir,result_dir_name,"pkl",f"{device_label}_EMG.pkl"))
+    result_dir = resolve_result_dir(faster_dir, result_dir_name)
+    EEG_raw=pd.read_pickle(os.path.join(result_dir,"pkl",f"{device_label}_EEG.pkl"))
+    EMG_raw=pd.read_pickle(os.path.join(result_dir,"pkl",f"{device_label}_EMG.pkl"))
     EEG_selected=EEG_raw[epoch_range]
     EMG_selected=EMG_raw[epoch_range]
     return EEG_selected,EMG_selected
     
-def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_circadian,result_dir_name="result"):
+def make_summary_stats(
+    mouse_info_df,
+    epoch_range,
+    epoch_len_sec,
+    stage_ext,
+    is_circadian,
+    result_dir_name="result",
+    time_in_hour_offset=0,
+):
     """ make summary statics of each mouse:
             stagetime in a day: how many minuites of stages each mouse spent in a day
             stage time profile: hourly profiles of stages over the recording
@@ -2239,6 +2335,7 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
     EMG_raw_list=[]
     stage_call_list=[]
 
+    total_mice = len(mouse_info_df)
     for i, r in mouse_info_df.iterrows():
         device_label = r['Device label'].strip()
         mouse_group = r['Mouse group'].strip()
@@ -2252,16 +2349,28 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
             continue
 
         # read a stage file
-        print_log(f'[{i+1}] Reading stage: {faster_dir} {device_label} {stage_ext}')
-        stage_call = et.read_stages(os.path.join(
-            faster_dir, result_dir_name), device_label, stage_ext)
-        print(len(stage_call))
-        stage_call = stage_call[epoch_range]
+        print_log(f'[{i+1}/{total_mice}] Reading stage: {faster_dir} {device_label} {stage_ext}')
+        result_dir = resolve_result_dir(faster_dir, result_dir_name)
+        stage_call = et.read_stages(str(result_dir), device_label, stage_ext)
+        stage_len = len(stage_call)
+        if isinstance(epoch_range, range):
+            epoch_end = min(epoch_range.stop, stage_len)
+            effective_epoch_range = range(epoch_range.start, epoch_end, epoch_range.step)
+        elif isinstance(epoch_range, slice):
+            stop = epoch_range.stop if epoch_range.stop is not None else stage_len
+            effective_epoch_range = slice(epoch_range.start, min(stop, stage_len), epoch_range.step)
+        else:
+            effective_epoch_range = [idx for idx in epoch_range if idx < stage_len]
+        if stage_len < (epoch_range.stop if isinstance(epoch_range, range) else stage_len):
+            print_log(
+                f'[{i+1}/{total_mice}] Trimming epoch range to {stage_len} stages '
+                f'for {faster_dir} {device_label}.'
+            )
+        stage_call = stage_call[effective_epoch_range]
         epoch_num_in_range = len(stage_call)
-        print(len(stage_call))
         
         #extract_raw_EEG_n_EMG
-        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,epoch_range)
+        eeg,emg=extract_raw_EEG_n_EMG(faster_dir,result_dir_name,device_label,effective_epoch_range)
         EEG_raw_list.append(eeg)
         EMG_raw_list.append(emg)
 
@@ -2326,11 +2435,22 @@ def make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_c
             'swtrans_profile': swtrans_profile_list,
             'swtrans_circadian': swtrans_circadian_profile_list,
             'epoch_num_in_range': epoch_num_in_range,
+            'time_in_hour_offset': time_in_hour_offset,
             'eeg':EEG_raw_list,
             'emg':EMG_raw_list,
             'stage_call':stage_call_list})
 
-def do_analysis(faster_dir_list,output_dir,stage_ext,vol_unit,epoch_range,epoch_len_sec,is_circadian,result_dir_name):
+def do_analysis(
+    faster_dir_list,
+    output_dir,
+    stage_ext,
+    vol_unit,
+    epoch_range,
+    epoch_len_sec,
+    is_circadian,
+    result_dir_name,
+    time_in_hour_offset=0,
+):
     # collect mouse_infos of the specified (multiple) FASTER dirs
     mouse_info_collected = collect_mouse_info_df(faster_dir_list, epoch_len_sec)
     mouse_info_df = mouse_info_collected['mouse_info']
@@ -2358,7 +2478,15 @@ def do_analysis(faster_dir_list,output_dir,stage_ext,vol_unit,epoch_range,epoch_
     os.makedirs(os.path.join(output_dir, 'log'), exist_ok=True)
 
     # prepare stagetime statistics
-    stagetime_stats = make_summary_stats(mouse_info_df, epoch_range, epoch_len_sec, stage_ext,is_circadian,result_dir_name)
+    stagetime_stats = make_summary_stats(
+        mouse_info_df,
+        epoch_range,
+        epoch_len_sec,
+        stage_ext,
+        is_circadian,
+        result_dir_name,
+        time_in_hour_offset=time_in_hour_offset,
+    )
     #stagetime_stats.to_csv(os.path.join(output_dir, 'stagetime_stats.csv'))
     #stagetime_stats.to_pickle(os.path.join(output_dir, 'stagetime_stats.pickle'))
     np.save(os.path.join(output_dir, 'stagetime_stats.npy'),stagetime_stats)
@@ -2458,7 +2586,16 @@ def do_analysis(faster_dir_list,output_dir,stage_ext,vol_unit,epoch_range,epoch_
     #process_psd_timeseries(psd_info_list, percentage_psd_info_list, epoch_range, epoch_len_sec, sample_freq, output_dir, 'raw', vol_unit)
 
 
-def analyze_project(prj_dir: Path, output_dir_name: str, epoch_len_sec: int, result_dir_name: str, faster_dir_list=None) -> None:
+def analyze_project(
+    prj_dir: Path,
+    output_dir_name: str,
+    epoch_len_sec: int,
+    result_dir_name: str,
+    faster_dir_list=None,
+    overwrite: bool = False,
+    injection_before_hours: float = 6,
+    injection_after_hours: float = 18,
+) -> None:
     """Run sleep stage and PSD analysis for the specified project directory."""
 
     prj_dir = Path(prj_dir)
@@ -2472,22 +2609,116 @@ def analyze_project(prj_dir: Path, output_dir_name: str, epoch_len_sec: int, res
     if not faster_dir_list:
         raise ValueError("No FASTER2 result directories were found.")
 
-    output_root = prj_dir.with_name(output_dir_name)
-    output_root.mkdir(parents=True, exist_ok=True)
+    def _output_root_for_faster_dir(faster_dir: str) -> Path:
+        faster_path = Path(faster_dir)
+        if faster_path.name == result_dir_name:
+            faster_path = faster_path.parent
+        if "raw_data" in faster_path.parts:
+            raw_data_index = faster_path.parts.index("raw_data")
+            base_dir = Path(*faster_path.parts[:raw_data_index]) or prj_dir.parent
+            rel_parts = list(faster_path.parts[raw_data_index + 1 :])
+            if rel_parts:
+                last_part = rel_parts[-1]
+                if last_part.startswith("raw_data"):
+                    suffix = last_part[len("raw_data") :]
+                    rel_parts[-1] = f"{output_dir_name}{suffix}"
+            rel_path = Path(*rel_parts)
+            return base_dir / output_dir_name / rel_path
+        return prj_dir / output_dir_name / faster_path.name
 
-    mouse_info = collect_mouse_info_df(faster_dir_list, epoch_len_sec)
-    epoch_range = range(0, mouse_info["epoch_num"])
+    def _detect_output_subdir(faster_dir: str, mouse_info_df: pd.DataFrame) -> Optional[str]:
+        candidates = []
+        for column in ("Note", "Experiment label"):
+            if column in mouse_info_df.columns:
+                values = [str(v).strip() for v in mouse_info_df[column].dropna().unique() if str(v).strip()]
+                candidates.extend(values)
+        candidates.append(str(faster_dir))
+        for value in candidates:
+            lower = value.lower()
+            if "vehicle" in lower:
+                return "vehicle_24h_before6h"
+            if "rapalog" in lower:
+                return "rapalog_24h_before6h"
+        return None
 
-    do_analysis(
-        faster_dir_list,
-        str(output_root),
-        stage_ext=None,
-        vol_unit="V",
-        epoch_range=epoch_range,
-        epoch_len_sec=epoch_len_sec,
-        is_circadian=False,
-        result_dir_name=result_dir_name,
-    )
+    def should_skip_output(output_dir: Path) -> bool:
+        if overwrite:
+            return False
+        if output_dir.exists() and (
+            (output_dir / "stagetime_stats.npy").exists()
+            or (output_dir / "psd_info_list.pkl").exists()
+        ):
+            print_log(f"Skip existing {output_dir} (use --overwrite to force re-run)")
+            return True
+        return False
+
+    for faster_dir in faster_dir_list:
+        output_root = _output_root_for_faster_dir(faster_dir)
+        output_root.mkdir(parents=True, exist_ok=True)
+        mouse_info = collect_mouse_info_df([faster_dir], epoch_len_sec)
+        exp_label = mouse_info["mouse_info"]["Experiment label"].iloc[0]
+        data_dir = resolve_data_dir(faster_dir)
+        drug_map = read_drug_info(data_dir, exp_label)
+        start_datetime = mouse_info["start_datetime"]
+
+        if drug_map:
+            for drug_name, injection_datetime in drug_map.items():
+                if drug_name not in ("vehicle", "rapalog"):
+                    continue
+                window_start = injection_datetime - pd.Timedelta(hours=injection_before_hours)
+                window_end = injection_datetime + pd.Timedelta(hours=injection_after_hours)
+                start_offset = max((window_start - start_datetime).total_seconds(), 0)
+                end_offset = max((window_end - start_datetime).total_seconds(), 0)
+                epoch_start = int(start_offset // epoch_len_sec)
+                epoch_end = int(end_offset // epoch_len_sec)
+                epoch_range = range(epoch_start, epoch_end)
+
+                output_subdir = format_injection_subdir(
+                    drug_name,
+                    injection_before_hours,
+                    injection_after_hours,
+                )
+                output_dir = output_root / output_subdir
+                output_dir.mkdir(parents=True, exist_ok=True)
+                if should_skip_output(output_dir):
+                    continue
+                do_analysis(
+                    [faster_dir],
+                    str(output_dir),
+                    stage_ext=None,
+                    vol_unit="V",
+                    epoch_range=epoch_range,
+                    epoch_len_sec=epoch_len_sec,
+                    is_circadian=False,
+                    result_dir_name=result_dir_name,
+                    time_in_hour_offset=-injection_before_hours,
+                )
+        else:
+            output_subdir = _detect_output_subdir(faster_dir, mouse_info["mouse_info"])
+            if output_subdir in ("vehicle_24h_before6h", "rapalog_24h_before6h"):
+                drug_name = output_subdir.split("_", 1)[0]
+                output_subdir = format_injection_subdir(
+                    drug_name,
+                    injection_before_hours,
+                    injection_after_hours,
+                )
+            output_dir = output_root / output_subdir if output_subdir else output_root
+            output_dir.mkdir(parents=True, exist_ok=True)
+            if should_skip_output(output_dir):
+                continue
+            epoch_range = range(0, mouse_info["epoch_num"])
+
+            do_analysis(
+                [faster_dir],
+                str(output_dir),
+                stage_ext=None,
+                vol_unit="V",
+                epoch_range=epoch_range,
+                epoch_len_sec=epoch_len_sec,
+                is_circadian=False,
+                result_dir_name=result_dir_name,
+                time_in_hour_offset=0,
+            )
 
 
 def main() -> None:
@@ -2497,6 +2728,9 @@ def main() -> None:
     parser.add_argument("--faster-dir-list", nargs="*", default=None, help="Explicit list of FASTER2 result directories to analyze")
     parser.add_argument("--epoch-len-sec", type=int, default=8, help="Epoch length used during preprocessing")
     parser.add_argument("--result-dir-name", default="result", help="Name of the preprocessing output directory")
+    parser.add_argument("--overwrite", action="store_true", help="Recreate outputs even if they already exist")
+    parser.add_argument("--injection-before-hours", type=float, default=6, help="Hours before injection to include")
+    parser.add_argument("--injection-after-hours", type=float, default=18, help="Hours after injection to include")
 
     args = parser.parse_args()
     analyze_project(
@@ -2505,6 +2739,9 @@ def main() -> None:
         args.epoch_len_sec,
         args.result_dir_name,
         faster_dir_list=args.faster_dir_list,
+        overwrite=args.overwrite,
+        injection_before_hours=args.injection_before_hours,
+        injection_after_hours=args.injection_after_hours,
     )
 
 

--- a/pipeline_step3_merge.py
+++ b/pipeline_step3_merge.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 import argparse
 import json
 
@@ -17,9 +18,20 @@ def merge_and_plot(
     comparison_drug="vehicle",
     mouse_groups_to_compare=None,
     quant_time_windows=None,
+    config_path=None,
 ):
     output_dir = Path(output_dir)
+    if comparison_mode == "mouse_group" and mouse_groups_to_compare:
+        compare_label = "_vs_".join(mouse_groups_to_compare)
+        output_dir = output_dir / compare_label
+    else:
+        output_dir = output_dir / target_group
     output_dir.mkdir(parents=True, exist_ok=True)
+    if config_path:
+        try:
+            shutil.copy2(config_path, output_dir / "config.json")
+        except FileNotFoundError:
+            print(f"[WARN] Config file not found for copy: {config_path}")
 
     merge_result = ana.merge_n_plot(
         analyzed_dir_list,
@@ -76,6 +88,7 @@ def main() -> None:
         help="Mouse groups to compare when comparison-mode is mouse_group (defaults to all groups found).",
     )
     parser.add_argument("--output-dir", type=Path, required=True, help="Directory to store merged outputs")
+    parser.add_argument("--config-path", type=Path, default=None, help="Optional config.json to copy into output dir")
     parser.add_argument("--epoch-len-sec", type=int, default=8)
     parser.add_argument("--sample-freq", type=int, default=128)
     parser.add_argument(
@@ -102,6 +115,7 @@ def main() -> None:
         args.comparison_drug,
         args.mouse_groups_to_compare,
         quant_time_windows,
+        args.config_path,
     )
 
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pipeline_step1_preprocess import preprocess_project
 from pipeline_step2_analyze import analyze_project
@@ -10,9 +10,25 @@ from pipeline_step3_merge import merge_and_plot
 
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_CONFIG_PATH = Path("/data/config.json")
+
+
+def resolve_config_path(config_path: Path) -> Path:
+    if config_path.is_dir():
+        config_path = config_path / "config.json"
+    if config_path.exists():
+        return config_path
+    if config_path != DEFAULT_CONFIG_PATH and DEFAULT_CONFIG_PATH.exists():
+        return DEFAULT_CONFIG_PATH
+    raise FileNotFoundError(
+        "Config file was not found. "
+        f"Tried: {config_path} and {DEFAULT_CONFIG_PATH}"
+    )
+
 
 def load_config(config_path: Path) -> Dict[str, Any]:
-    with config_path.open() as f:
+    resolved_path = resolve_config_path(config_path)
+    with resolved_path.open() as f:
         return json.load(f)
 
 
@@ -33,6 +49,9 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
         "faster_dir_list": None,
         "epoch_len_sec": preprocess["epoch_len_sec"],
         "result_dir_name": preprocess["result_dir_name"],
+        "overwrite": preprocess["overwrite"],
+        "injection_before_hours": 6,
+        "injection_after_hours": 18,
         **config.get("analysis", {}),
     }
 
@@ -54,8 +73,10 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
     return {"preprocess": preprocess, "analysis": analysis, "merge": merge}
 
 
-def run_pipeline(config_path: Path, executed_dir: Path | None = None) -> None:
-    config = ensure_defaults(load_config(config_path))
+def run_pipeline(config_path: Path, executed_dir: Optional[Path] = None) -> None:
+    resolved_path = resolve_config_path(config_path)
+    config = ensure_defaults(load_config(resolved_path))
+    config["merge"]["config_path"] = str(resolved_path)
     LOGGER.info("Starting preprocessing step")
     preprocess_project(**config["preprocess"])
 
@@ -73,8 +94,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config",
         type=Path,
-        required=True,
-        help="Path to JSON configuration file describing inputs and outputs.",
+        default=DEFAULT_CONFIG_PATH,
+        help=(
+            "Path to JSON configuration file describing inputs and outputs "
+            "(default: /data/config.json)."
+        ),
     )
     parser.add_argument(
         "--executed-dir",


### PR DESCRIPTION
### Motivation
- Reduce complexity by avoiding duplicate filename variants per injection window and instead use window-specific output folders for labeled analyses.
- Make analysis outputs and PSD handling more robust to missing/mismatched files, variable epoch ranges, and mask-length differences to avoid runtime crashes.
- Ensure analysis `time_in_hour` indices reflect configured injection-centered windows via a threaded `time_in_hour_offset` and window computation from `drug.info.csv`.

### Description
- Removed writing of window-suffixed files and now always save `stagetime_stats.npy` and `psd_info_list.pkl` inside window-specific folders rather than creating `stagetime_stats_{label}.npy` / `psd_info_list_{label}.pkl` variants.
- Added injection-window discovery and per-window output folder creation using `drug.info.csv` (parsed with `parse_dates`) and `format_injection_subdir`, and pass `time_in_hour_offset` into `do_analysis` to align `time_in_hour` indices.
- Hardened PSD and merge logic: tolerate mask/length mismatches, trim epoch ranges safely, perform numeric-only interpolation grouped by `Mouse ID`/`Stage`, add fallbacks and warnings for missing files, and make plots use dynamic x-axes (changes across `faster2lib/summary_psd.py`, `analysis.py`, and `pipeline_step2_analyze.py`).
- Miscellaneous improvements: more robust data-dir resolution, safer summary-stat handling (including `safe_wilcoxon`), `run_pipeline.py` config resolution/default, and optional copying of `config.json` in `pipeline_step3_merge.py`.

### Testing
- No automated unit or integration tests were executed for these changes.
- Changes were committed locally; no automated CI was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955e57429708331a845c3f5ee32ced6)