### PR TITLE
Generalize drug handling for multi-condition comparisons and plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Use `--config /path/to/other.json` when you want to run with a different configu
     "comparison_mode": "drug",
     "comparison_drug": "vehicle",
     "mouse_groups_to_compare": [],
+    "drug_names": ["vehicle", "drugA", "drugB"],
     "output_dir": "/data/figures/kaist",
     "epoch_len_sec": 8,
     "sample_freq": 128,
@@ -252,14 +253,22 @@ EEG_p-iino-1-1,EEG_A-E,2025/11/21 7:00,2025/12/5 7:00,128
 #### Rules
 
 * `drugX_name` and `drugX_datetime` must appear as **pairs**
-* `drugX_name` must include `vehicle` and `rapalog`
-* Matching is **case-sensitive** (use lowercase)
+* `X` can be variable length (`drug1`, `drug2`, `drug3`, ...)
+* Drug names are normalized to lowercase in the pipeline
+* The merge step uses `merge.drug_names` to select and order conditions for plotting
 
 #### Example
 
 ```csv
 ...,drug1_datetime,drug1_name,drug2_datetime,drug2_name
 ...,2025/12/2 17:00,vehicle,2025/12/3 17:00,rapalog
+```
+
+You can also provide 3+ conditions, for example:
+
+```csv
+...,drug1_datetime,drug1_name,drug2_datetime,drug2_name,drug3_datetime,drug3_name,drug4_datetime,drug4_name
+...,2025/12/2 17:00,vehicle,2025/12/3 17:00,druga,2025/12/4 17:00,drugb,2025/12/5 17:00,drugc
 ```
 
 ---
@@ -337,11 +346,22 @@ This step generates **hypnograms**, **PSD plots**, and **summary figures**.
 By default, plots are written under `output_dir/<target_group>/` to avoid overwriting
 results when multiple mouse groups are analyzed.
 
-* Use `--comparison-mode drug` (default) to compare two drugs within a single mouse group (legacy behavior controlled by `--target-group`).
+* Use `--comparison-mode drug` (default) to compare one or more drug conditions within a single mouse group (legacy behavior controlled by `--target-group`).
+* Set the drug list with `--drug-names vehicle drugA drugB` (or via `merge.drug_names` in config).
 * Use `--comparison-mode mouse_group` with `--comparison-drug vehicle` (or `rapalog`) and
   `--mouse-groups-to-compare WT KO` to generate WT vs KO plots. Outputs go under
   `output_dir/WT_vs_KO/` when `mouse_groups_to_compare` is provided.
 * Use `--comparison-mode mouse_group` to compare two mouse groups within a single drug; set the reference drug with `--comparison-drug` and optionally limit groups via `--mouse-groups-to-compare`.
+
+### Quick Reference (drug condition setup)
+
+* 2-condition (legacy): `drug_names: ["vehicle", "rapalog"]`
+* 3-condition: `drug_names: ["vehicle", "drugA", "drugB"]`
+* 4-condition: `drug_names: ["vehicle", "drugA", "drugB", "drugC"]`
+* Keep names consistent between:
+  * `drug.info.csv` (`drugX_name`)
+  * analyzed subdirectory names generated in step2 (`<drug>_before..._after...`)
+  * merge configuration (`merge.drug_names`)
 
 ### Minimal Workflow Summary
 

--- a/analysis.py
+++ b/analysis.py
@@ -27,6 +27,18 @@ import warnings
 import seaborn as sns
 import math
 
+DEFAULT_DRUGS = ("vehicle", "rapalog")
+
+
+def _ordered_drug_list(drugs):
+    unique = []
+    for d in drugs:
+        if d not in unique:
+            unique.append(d)
+    if "vehicle" in unique:
+        unique = ["vehicle"] + [d for d in unique if d != "vehicle"]
+    return unique
+
 def psd_freq_bins(sample_freq):
     """ assures frequency bins compatibe among different sampling frequencies
 
@@ -393,48 +405,29 @@ def merge_psd_ts_csv(dir):
     merge_df = pd.concat(merge_list, ignore_index=False)  # インデックスを保持する場合は ignore_index=False
     return merge_df
 
-def meta_merge_psd_csv(analyzed_dir_list, subdir_vehicle, subdir_rapalog):
+def meta_merge_psd_csv(analyzed_dir_list, drug_subdir_map):
     psd_ts_list = []  # PSD timeseries データフレームを格納するリスト
     psd_profile_list = []  # PSD profile データフレームを格納するリスト
 
     for dir in analyzed_dir_list:
-        # Vehicle データの処理
-        df_append_vehicle = merge_hourly_psd_ts_csv(os.path.join(dir, subdir_vehicle, "PSD_raw"))
-        if not df_append_vehicle.empty:
-            df_append_vehicle = add_index(df_append_vehicle, "drug", "vehicle")
-            psd_ts_list.append(df_append_vehicle)  # リストに追加
+        for drug_name, subdir in drug_subdir_map.items():
+            df_append = merge_hourly_psd_ts_csv(os.path.join(dir, subdir, "PSD_raw"))
+            if not df_append.empty:
+                df_append = add_index(df_append, "drug", drug_name)
+                psd_ts_list.append(df_append)
 
-        # Rapalog データの処理
-        df_append_rapalog = merge_hourly_psd_ts_csv(os.path.join(dir, subdir_rapalog, "PSD_raw"))
-        if not df_append_rapalog.empty:
-            df_append_rapalog = add_index(df_append_rapalog, "drug", "rapalog")
-            psd_ts_list.append(df_append_rapalog)  # リストに追加
-
-        # Profile データの処理
-        csv_fname = "PSD_norm_allday_percentage-profile.csv"
-        vehicle_profile_path = os.path.join(dir, subdir_vehicle, "PSD_norm", csv_fname)
-        if not os.path.exists(vehicle_profile_path):
-            fallback_vehicle = Path(dir) / "PSD_norm" / csv_fname
-            if fallback_vehicle.exists():
-                vehicle_profile_path = str(fallback_vehicle)
-        if os.path.exists(vehicle_profile_path):
-            df_profile_append_vehicle = read_psd_profile_csv(vehicle_profile_path)
-            df_profile_append_vehicle = add_index(df_profile_append_vehicle, "drug", "vehicle")
-            psd_profile_list.append(df_profile_append_vehicle)  # リストに追加
-        else:
-            print(f"[WARN] Missing PSD profile CSV, skipping: {vehicle_profile_path}")
-
-        rapalog_profile_path = os.path.join(dir, subdir_rapalog, "PSD_norm", csv_fname)
-        if not os.path.exists(rapalog_profile_path):
-            fallback_rapalog = Path(dir) / "PSD_norm" / csv_fname
-            if fallback_rapalog.exists():
-                rapalog_profile_path = str(fallback_rapalog)
-        if os.path.exists(rapalog_profile_path):
-            df_profile_append_rapalog = read_psd_profile_csv(rapalog_profile_path)
-            df_profile_append_rapalog = add_index(df_profile_append_rapalog, "drug", "rapalog")
-            psd_profile_list.append(df_profile_append_rapalog)  # リストに追加
-        else:
-            print(f"[WARN] Missing PSD profile CSV, skipping: {rapalog_profile_path}")
+            csv_fname = "PSD_norm_allday_percentage-profile.csv"
+            profile_path = os.path.join(dir, subdir, "PSD_norm", csv_fname)
+            if not os.path.exists(profile_path):
+                fallback_path = Path(dir) / "PSD_norm" / csv_fname
+                if fallback_path.exists():
+                    profile_path = str(fallback_path)
+            if os.path.exists(profile_path):
+                df_profile_append = read_psd_profile_csv(profile_path)
+                df_profile_append = add_index(df_profile_append, "drug", drug_name)
+                psd_profile_list.append(df_profile_append)
+            else:
+                print(f"[WARN] Missing PSD profile CSV, skipping: {profile_path}")
 
     # リスト内のデータフレームを結合
     merge_psd_ts_df = pd.concat(psd_ts_list, ignore_index=False) if psd_ts_list else pd.DataFrame()
@@ -480,57 +473,44 @@ def read_psd_profile_csv(csvpath):
     return merge_df
 
 
-def process_stats_path_list(analyzed_dir_list, vehicle_path, rapalog_path):
-    stats_list_vehicle=[]
-    stats_list_rapalog=[]
-    #vehicle_path="vehicle_60h/stagetime_stats.npy"
-    #rapalog_path="rapalog_60h/stagetime_stats.npy"
-    #vehicle_path="vehicle_84h_before_24h_after_60h/stagetime_stats.npy"
-    #rapalog_path="rapalog_84h_before_24h_after_60h/stagetime_stats.npy"
+def process_stats_path_list(analyzed_dir_list, drug_stats_paths):
+    stats_map = {drug_name: [] for drug_name in drug_stats_paths}
     for dir in analyzed_dir_list:
-        vehicle_stats = os.path.join(dir, vehicle_path)
-        rapalog_stats = os.path.join(dir, rapalog_path)
         fallback_stats = os.path.join(dir, "stagetime_stats.npy")
-        if not os.path.exists(vehicle_stats) and os.path.exists(fallback_stats):
-            vehicle_stats = fallback_stats
-        if not os.path.exists(rapalog_stats) and os.path.exists(fallback_stats):
-            rapalog_stats = fallback_stats
-        stats_list_vehicle.append(vehicle_stats)
-        stats_list_rapalog.append(rapalog_stats)
-    return stats_list_vehicle,stats_list_rapalog
+        for drug_name, rel_path in drug_stats_paths.items():
+            drug_stats = os.path.join(dir, rel_path)
+            if not os.path.exists(drug_stats) and os.path.exists(fallback_stats):
+                drug_stats = fallback_stats
+            stats_map[drug_name].append(drug_stats)
+    return stats_map
 
-def process_psd_info_path_list(analyzed_dir_list, injection_before_hours=6, injection_after_hours=18):
-    psd_info_list_vehicle=[]
-    psd_info_list_rapalog=[]
+def process_psd_info_path_list(analyzed_dir_list, drug_names, injection_before_hours=6, injection_after_hours=18):
+    psd_info_map = {drug_name: [] for drug_name in drug_names}
     window_suffix = f"before{int(injection_before_hours)}h_after{int(injection_after_hours)}h"
-    vehicle_path=f"vehicle_{window_suffix}/psd_info_list.pkl"
-    rapalog_path=f"rapalog_{window_suffix}/psd_info_list.pkl"
-    #vehicle_path="vehicle_84h_before_24h_after_60h/stagetime_stats.npy"
-    #rapalog_path="rapalog_84h_before_24h_after_60h/stagetime_stats.npy"
     for dir in analyzed_dir_list:
-        vehicle_info = os.path.join(dir, vehicle_path)
-        rapalog_info = os.path.join(dir, rapalog_path)
         fallback_info = os.path.join(dir, "psd_info_list.pkl")
-        if not os.path.exists(vehicle_info) and os.path.exists(fallback_info):
-            vehicle_info = fallback_info
-        if not os.path.exists(rapalog_info) and os.path.exists(fallback_info):
-            rapalog_info = fallback_info
-        psd_info_list_vehicle.append(vehicle_info)
-        psd_info_list_rapalog.append(rapalog_info)
-    return psd_info_list_vehicle,psd_info_list_rapalog
+        for drug_name in drug_names:
+            rel_path = f"{drug_name}_{window_suffix}/psd_info_list.pkl"
+            drug_info = os.path.join(dir, rel_path)
+            if not os.path.exists(drug_info) and os.path.exists(fallback_info):
+                drug_info = fallback_info
+            psd_info_map[drug_name].append(drug_info)
+    return psd_info_map
 
 def merge_individual_df(
     analyzed_dir_list,
-    vehicle_path,
-    rapalog_path,
+    drug_stats_paths,
     epoch_len_sec,
     ample_freq,
+    drug_names=DEFAULT_DRUGS,
     injection_before_hours=6,
     injection_after_hours=18,
 ):
-    stats_list_vehicle, stats_list_rapalog = process_stats_path_list(analyzed_dir_list, vehicle_path, rapalog_path)
-    psd_info_list_vehicle, psd_info_list_rapalog = process_psd_info_path_list(
+    drug_names = _ordered_drug_list(drug_names)
+    stats_map = process_stats_path_list(analyzed_dir_list, drug_stats_paths)
+    psd_info_map = process_psd_info_path_list(
         analyzed_dir_list,
+        drug_names,
         injection_before_hours=injection_before_hours,
         injection_after_hours=injection_after_hours,
     )
@@ -540,47 +520,22 @@ def merge_individual_df(
     meta_merge_list3 = []  # meta_merge_df3用リスト
     psd_start_n_end_list = []  # psd_start_n_end_df用リスト
     
-    # Vehicleデータの処理
-    for stats in stats_list_vehicle:
-        if not os.path.exists(stats):
-            print(f"[WARN] Missing stats file, skipping: {stats}")
-            continue
-        df, df2, df3 = make_df_from_summary_dic(stats)
-        df = add_index(df, "drug", "vehicle")
-        meta_merge_list.append(df)
-        df2 = add_index(df2, "drug", "vehicle")
-        meta_merge_list2.append(df2)
-        df3 = add_index(df3, "drug", "vehicle")
-        meta_merge_list3.append(df3)
-    
-    for psd_info_list in psd_info_list_vehicle:
-        if not os.path.exists(psd_info_list):
-            print(f"[WARN] Missing PSD info file, skipping: {psd_info_list}")
-            continue
-        df4 = extract_psd_from_psdinfo(psd_info_list, epoch_len_sec, ample_freq)
-        df4 = add_index(df4, "drug", "vehicle")
-        psd_start_n_end_list.append(df4)
-    
-    # Rapalogデータの処理
-    for stats in stats_list_rapalog:
-        if not os.path.exists(stats):
-            print(f"[WARN] Missing stats file, skipping: {stats}")
-            continue
-        df, df2, df3 = make_df_from_summary_dic(stats)
-        df = add_index(df, "drug", "rapalog")
-        meta_merge_list.append(df)
-        df2 = add_index(df2, "drug", "rapalog")
-        meta_merge_list2.append(df2)
-        df3 = add_index(df3, "drug", "rapalog")
-        meta_merge_list3.append(df3)
-    
-    for psd_info_list in psd_info_list_rapalog:
-        if not os.path.exists(psd_info_list):
-            print(f"[WARN] Missing PSD info file, skipping: {psd_info_list}")
-            continue
-        df4 = extract_psd_from_psdinfo(psd_info_list, epoch_len_sec, ample_freq)
-        df4 = add_index(df4, "drug", "rapalog")
-        psd_start_n_end_list.append(df4)
+    for drug_name in drug_names:
+        for stats in stats_map.get(drug_name, []):
+            if not os.path.exists(stats):
+                print(f"[WARN] Missing stats file, skipping: {stats}")
+                continue
+            df, df2, df3 = make_df_from_summary_dic(stats)
+            meta_merge_list.append(add_index(df, "drug", drug_name))
+            meta_merge_list2.append(add_index(df2, "drug", drug_name))
+            meta_merge_list3.append(add_index(df3, "drug", drug_name))
+
+        for psd_info_list in psd_info_map.get(drug_name, []):
+            if not os.path.exists(psd_info_list):
+                print(f"[WARN] Missing PSD info file, skipping: {psd_info_list}")
+                continue
+            df4 = extract_psd_from_psdinfo(psd_info_list, epoch_len_sec, ample_freq)
+            psd_start_n_end_list.append(add_index(df4, "drug", drug_name))
     
     # pd.concatでリスト内のデータフレームを結合
     if not meta_merge_list:
@@ -624,27 +579,30 @@ def calculate_delta(meta_merge_df):
     return(delta_df)
 
 def merge_sleep_stage_df(analyzed_dir_list, epoch_len_sec, sample_freq,
-                         injection_before_hours=6, injection_after_hours=18):
+                         injection_before_hours=6, injection_after_hours=18,
+                         drug_names=DEFAULT_DRUGS):
     window_suffix = f"before{int(injection_before_hours)}h_after{int(injection_after_hours)}h"
-    vehicle_path = f"vehicle_{window_suffix}/stagetime_stats.npy"
-    rapalog_path = f"rapalog_{window_suffix}/stagetime_stats.npy"
+    drug_names = _ordered_drug_list(drug_names)
+    drug_stats_paths = {
+        drug_name: f"{drug_name}_{window_suffix}/stagetime_stats.npy" for drug_name in drug_names
+    }
     meta_stage_df,meta_merge_df_sw,meta_stage_bout_df,meta_psd_start_end_df=merge_individual_df(
         analyzed_dir_list,
-        vehicle_path,
-        rapalog_path,
+        drug_stats_paths,
         epoch_len_sec,
         sample_freq,
+        drug_names=drug_names,
         injection_before_hours=injection_before_hours,
         injection_after_hours=injection_after_hours,
     )
     return meta_stage_df,meta_merge_df_sw,meta_stage_bout_df,meta_psd_start_end_df
 
-def merge_psd_df(analyzed_dir_list, injection_before_hours=6, injection_after_hours=18):
+def merge_psd_df(analyzed_dir_list, injection_before_hours=6, injection_after_hours=18, drug_names=DEFAULT_DRUGS):
     window_suffix = f"before{int(injection_before_hours)}h_after{int(injection_after_hours)}h"
-    subdir_vehicle = f"vehicle_{window_suffix}"
-    subdir_rapalog = f"rapalog_{window_suffix}"
+    drug_names = _ordered_drug_list(drug_names)
+    drug_subdir_map = {drug_name: f"{drug_name}_{window_suffix}" for drug_name in drug_names}
     merge_psd_ts_df,merge_psd_profile_df=meta_merge_psd_csv(
-        analyzed_dir_list, subdir_vehicle, subdir_rapalog
+        analyzed_dir_list, drug_subdir_map
     )
     return merge_psd_ts_df,merge_psd_profile_df
 
@@ -713,24 +671,23 @@ def plot_light_dark_bar(ax, x_min, x_max, light_on=5, dark_on=17, line_width=5):
         ax.plot([current, next_boundary], [y_pos, y_pos], linewidth=line_width, color=color, solid_capstyle="butt")
         current = next_boundary
 
-def plot_ts_1group(mean,sem,count,g_name,sleep_stage,ax1,val_name,y_label):
-    x_val, y, err=extract_mean_n_err(mean,sem,g_name,"vehicle",sleep_stage,val_name)
-    sample_n=count.loc[pd.IndexSlice[g_name,"vehicle",sleep_stage,0]][0]
-    #label_str="vehicle (n=%d)"%sample_n
-    label_str="vehicle"
-    plot_timeseries(ax1,x_val,y,err,"k",label_str)
-
-    x_min = float(np.min(x_val)) if x_val.size else 0
-    x_max = float(np.max(x_val)) if x_val.size else 0
-    x_val, y, err=extract_mean_n_err(mean,sem,g_name,"rapalog",sleep_stage,val_name)
-    sample_n=count.loc[pd.IndexSlice[g_name,"rapalog",sleep_stage,0]][0]
-    #label_str="rapalog (n=%d)"%sample_n
-    label_str="rapalog"
-    plot_timeseries(ax1,x_val,y,err,"r",label_str)
-    
-    if x_val.size:
-        x_min = min(x_min, float(np.min(x_val)))
-        x_max = max(x_max, float(np.max(x_val)))
+def plot_ts_1group(mean,sem,count,g_name,sleep_stage,ax1,val_name,y_label,drug_names):
+    palette = dict(zip(drug_names, sns.color_palette("colorblind", n_colors=len(drug_names))))
+    x_min = 0
+    x_max = 0
+    plotted_any = False
+    for drug_name in drug_names:
+        try:
+            x_val, y, err = extract_mean_n_err(mean, sem, g_name, drug_name, sleep_stage, val_name)
+            plot_timeseries(ax1, x_val, y, err, palette[drug_name], drug_name)
+            plotted_any = True
+            if x_val.size:
+                x_min = min(x_min, float(np.min(x_val)))
+                x_max = max(x_max, float(np.max(x_val)))
+        except KeyError:
+            print(f"[WARN] plot_ts_1group: data missing for drug={drug_name}, stage={sleep_stage}")
+    if not plotted_any:
+        return
     for ax in [ax1]:
         if val_name=="min_per_hour":
             if sleep_stage=="REM":
@@ -870,22 +827,21 @@ def plot_ts_mouse_groups(mean, sem, count, mouse_groups, drug, sleep_stage, ax1,
         #plot_light_dark_bar(ax, x_min, x_max)
     plt.subplots_adjust(wspace=0.4, hspace=0.6)
 
-def plot_PSD_1group(mean,sem,count,g_name,sleep_stage,ax1,y_label):
+def plot_PSD_1group(mean,sem,count,g_name,sleep_stage,ax1,y_label,drug_names):
     freq_bins=sp.psd_freq_bins(sample_freq=128)
-    frequency_columns = [f"f@{i}" for i in freq_bins]
     x_val=freq_bins
-    
-    y,err=extract_mean_n_err_for_PSD(mean,sem,g_name,"vehicle",sleep_stage)
-    sample_n=count.loc[pd.IndexSlice[g_name,"vehicle",sleep_stage]].max()
-    #label_str="vehicle (n=%d)"%sample_n
-    label_str="vehicle"
-    plot_timeseries(ax1,x_val,y,err,"k",label_str)
-
-    y,err=extract_mean_n_err_for_PSD(mean,sem,g_name,"rapalog",sleep_stage)
-    sample_n=count.loc[pd.IndexSlice[g_name,"rapalog",sleep_stage]].max()
-    #label_str="rapalog (n=%d)"%sample_n
-    label_str="rapalog"
-    plot_timeseries(ax1,x_val,y,err,"r",label_str)
+    palette = dict(zip(drug_names, sns.color_palette("colorblind", n_colors=len(drug_names))))
+    plotted_any = False
+    for drug_name in drug_names:
+        try:
+            y, err = extract_mean_n_err_for_PSD(mean, sem, g_name, drug_name, sleep_stage)
+        except KeyError:
+            print(f"[WARN] plot_PSD_1group: data missing for drug={drug_name}, stage={sleep_stage}")
+            continue
+        plot_timeseries(ax1, x_val, y, err, palette[drug_name], drug_name)
+        plotted_any = True
+    if not plotted_any:
+        return
     
     for ax in [ax1]:
         #ax.set_ylabel("NREM sleep duration (min/h)")
@@ -951,22 +907,21 @@ def plot_PSD_mouse_groups(mean, sem, count, mouse_groups, drug, sleep_stage, ax1
     plt.subplots_adjust(wspace=0.4, hspace=0.6)
 
 
-def plot_PSD_1group_zoom(mean,sem,count,g_name,sleep_stage,ax1,y_label):
+def plot_PSD_1group_zoom(mean,sem,count,g_name,sleep_stage,ax1,y_label,drug_names):
     freq_bins=sp.psd_freq_bins(sample_freq=128)
-    frequency_columns = [f"f@{i}" for i in freq_bins]
     x_val=freq_bins
-    
-    y,err=extract_mean_n_err_for_PSD(mean,sem,g_name,"vehicle",sleep_stage)
-    sample_n=count.loc[pd.IndexSlice[g_name,"vehicle",sleep_stage]].max()
-    #label_str="vehicle (n=%d)"%sample_n
-    label_str="vehicle"
-    plot_timeseries(ax1,x_val,y,err,"k",label_str)
-
-    y,err=extract_mean_n_err_for_PSD(mean,sem,g_name,"rapalog",sleep_stage)
-    sample_n=count.loc[pd.IndexSlice[g_name,"rapalog",sleep_stage]].max()
-    #label_str="rapalog (n=%d)"%sample_n
-    label_str="rapalog"
-    plot_timeseries(ax1,x_val,y,err,"r",label_str)
+    palette = dict(zip(drug_names, sns.color_palette("colorblind", n_colors=len(drug_names))))
+    plotted_any = False
+    for drug_name in drug_names:
+        try:
+            y, err = extract_mean_n_err_for_PSD(mean, sem, g_name, drug_name, sleep_stage)
+        except KeyError:
+            print(f"[WARN] plot_PSD_1group_zoom: data missing for drug={drug_name}, stage={sleep_stage}")
+            continue
+        plot_timeseries(ax1, x_val, y, err, palette[drug_name], drug_name)
+        plotted_any = True
+    if not plotted_any:
+        return
     
     for ax in [ax1]:
         #ax.set_ylabel("NREM sleep duration (min/h)")
@@ -1035,7 +990,7 @@ def plot_PSD_mouse_groups_zoom(mean, sem, count, mouse_groups, drug, sleep_stage
     plt.subplots_adjust(wspace=0.4, hspace=0.6)
 
 
-def plot_bargraph(df, target_group, sleep_stage, y_value, y_label, ax, is_norm=False):
+def plot_bargraph(df, target_group, sleep_stage, y_value, y_label, ax, drug_names, is_norm=False):
     """
     df: index は何でもOK（MultiIndex / 単一 Index 両方対応）
         必要カラム: mouse_group, mouse_ID, stage, drug, y_value
@@ -1053,29 +1008,27 @@ def plot_bargraph(df, target_group, sleep_stage, y_value, y_label, ax, is_norm=F
         return
 
     # barplot 本体（x='drug', y=y_value）
+    ordered_drugs = [d for d in drug_names if d in sub["drug"].unique()]
+    palette = dict(zip(ordered_drugs, sns.color_palette("colorblind", n_colors=len(ordered_drugs))))
     sns.barplot(
         data=sub,
         x="drug",
         y=y_value,
-        hue="drug",              # ← 追加！
-        palette={"rapalog": "r", "vehicle": "gray"},
-        dodge=False,             # ← hue があってもバーを重ねる
-        legend=False,            # ← 凡例を非表示に（警告メッセージが推奨している方法）
-        ax=ax
+        hue="drug",
+        palette=palette,
+        dodge=False,
+        legend=False,
+        order=ordered_drugs,
+        ax=ax,
     )
 
-    # rapalog-vehicle のペア線をマウスごとに引く
-    for mouse_id, g in sub.groupby("mouse_ID"):
-        # 両方揃っているマウスだけ線を引く
-        if not {"vehicle", "rapalog"}.issubset(set(g["drug"])):
-            continue
-
-        # rapalog, vehicle の値（複数行あっても平均してOK）
-        val_rapa = g.loc[g["drug"] == "rapalog", y_value].mean()
-        val_veh  = g.loc[g["drug"] == "vehicle", y_value].mean()
-
-        # seaborn の x 軸カテゴリは ['rapalog','vehicle'] の順になる想定なので x=0,1 に線を引く
-        ax.plot([0, 1], [val_rapa, val_veh], color="k", alpha=0.7)
+    if len(ordered_drugs) == 2:
+        for _, g in sub.groupby("mouse_ID"):
+            if not set(ordered_drugs).issubset(set(g["drug"])):
+                continue
+            left = g.loc[g["drug"] == ordered_drugs[0], y_value].mean()
+            right = g.loc[g["drug"] == ordered_drugs[1], y_value].mean()
+            ax.plot([0, 1], [left, right], color="k", alpha=0.7)
 
     # 以下、元コードの軸スケール設定などはそのまま流用
     for ax in [ax]:
@@ -1119,9 +1072,9 @@ def plot_bargraph(df, target_group, sleep_stage, y_value, y_label, ax, is_norm=F
                 ax.set_yticks([0,10,20])
 
         ax.set_ylabel(y_label)
-        ax.set_xticks([0,1])
-        ax.set_xticklabels(["rapalog","vehicle"], rotation=90)
-        ax.set_xlim([-0.5,1.5])
+        ax.set_xticks(range(len(ordered_drugs)))
+        ax.set_xticklabels(ordered_drugs, rotation=90)
+        ax.set_xlim([-0.5, len(ordered_drugs)-0.5])
         ax.set_xlabel("")
         ax.spines['right'].set_visible(False)
         ax.spines['top'].set_visible(False)
@@ -1422,7 +1375,9 @@ def merge_n_plot(
     quant_time_windows=None,
     injection_before_hours=6,
     injection_after_hours=18,
+    drug_names=DEFAULT_DRUGS,
 ):
+    drug_names = _ordered_drug_list(drug_names)
     quant_time_windows = quant_time_windows or {}
 
     def get_window(key, default):
@@ -1454,6 +1409,7 @@ def merge_n_plot(
         sample_freq,
         injection_before_hours=injection_before_hours,
         injection_after_hours=injection_after_hours,
+        drug_names=drug_names,
     )
     if meta_stage_df.empty:
         print("[WARN] No merged stagetime data available; skipping plot generation.")
@@ -1467,6 +1423,7 @@ def merge_n_plot(
         analyzed_dir_list,
         injection_before_hours=injection_before_hours,
         injection_after_hours=injection_after_hours,
+        drug_names=drug_names,
     )
     
     #rename group if needed
@@ -1575,28 +1532,28 @@ def merge_n_plot(
         if comparison_mode == "mouse_group":
             plot_ts_mouse_groups(mean, sem, count, selected_mouse_groups, comparison_drug, sleep_stage, ax, val_name, y_label)
         else:
-            plot_ts_1group(mean, sem, count, target_group, sleep_stage, ax, val_name, y_label)
+            plot_ts_1group(mean, sem, count, target_group, sleep_stage, ax, val_name, y_label, drug_names)
 
 
     def plot_psd_dispatch(mean, sem, count, sleep_stage, ax, y_label):
         if comparison_mode == "mouse_group":
             plot_PSD_mouse_groups(mean, sem, count, selected_mouse_groups, comparison_drug, sleep_stage, ax, y_label)
         else:
-            plot_PSD_1group(mean, sem, count, target_group, sleep_stage, ax, y_label)
+            plot_PSD_1group(mean, sem, count, target_group, sleep_stage, ax, y_label, drug_names)
 
 
     def plot_psd_zoom_dispatch(mean, sem, count, sleep_stage, ax, y_label):
         if comparison_mode == "mouse_group":
             plot_PSD_mouse_groups_zoom(mean, sem, count, selected_mouse_groups, comparison_drug, sleep_stage, ax, y_label)
         else:
-            plot_PSD_1group_zoom(mean, sem, count, target_group, sleep_stage, ax, y_label)
+            plot_PSD_1group_zoom(mean, sem, count, target_group, sleep_stage, ax, y_label, drug_names)
 
 
     def plot_bar_dispatch(df, sleep_stage, y_value, y_label, ax, is_norm=False):
         if comparison_mode == "mouse_group":
             plot_bargraph_mouse_groups(df, selected_mouse_groups, comparison_drug, sleep_stage, y_value, y_label, ax, is_norm=is_norm)
         else:
-            plot_bargraph(df, target_group, sleep_stage, y_value, y_label, ax, is_norm=is_norm)
+            plot_bargraph(df, target_group, sleep_stage, y_value, y_label, ax, drug_names, is_norm=is_norm)
 
     
     

--- a/pipeline.config.example.json
+++ b/pipeline.config.example.json
@@ -24,6 +24,7 @@
     "comparison_mode": "drug",
     "comparison_drug": "vehicle",
     "mouse_groups_to_compare": [],
+    "drug_names": ["vehicle", "drugA", "drugB"],
     "output_dir": "/data/figures/kaist",
     "epoch_len_sec": 8,
     "sample_freq": 128,

--- a/pipeline_step2_analyze.py
+++ b/pipeline_step2_analyze.py
@@ -141,21 +141,30 @@ def read_drug_info(data_dir: Path, exp_label: str) -> dict:
     drug_info_path = data_dir / "drug.info.csv"
     if not drug_info_path.exists():
         return {}
-    drug_info_df = pd.read_csv(drug_info_path, parse_dates=["drug1_datetime", "drug2_datetime"])
+    drug_info_df = pd.read_csv(drug_info_path)
     row = drug_info_df.loc[drug_info_df["Experiment label"] == exp_label]
     if row.empty:
         return {}
     row = row.iloc[0]
     drug_map = {}
-    for idx in (1, 2):
-        name_col = f"drug{idx}_name"
-        datetime_col = f"drug{idx}_datetime"
-        if name_col not in row or datetime_col not in row:
+    drug_cols = {}
+    for col in row.index:
+        m = re.fullmatch(r"drug(\d+)_(name|datetime)", str(col))
+        if not m:
+            continue
+        idx = int(m.group(1))
+        kind = m.group(2)
+        drug_cols.setdefault(idx, {})[kind] = col
+
+    for idx in sorted(drug_cols):
+        name_col = drug_cols[idx].get("name")
+        datetime_col = drug_cols[idx].get("datetime")
+        if not name_col or not datetime_col:
             continue
         name = str(row[name_col]).strip().lower()
         if not name or name == "nan":
             continue
-        dt_raw = row[datetime_col]
+        dt_raw = pd.to_datetime(row[datetime_col], errors="coerce")
         if pd.isna(dt_raw):
             continue
         drug_map[name] = dt_raw
@@ -2663,8 +2672,6 @@ def analyze_project(
 
         if drug_map:
             for drug_name, injection_datetime in drug_map.items():
-                if drug_name not in ("vehicle", "rapalog"):
-                    continue
                 window_start = injection_datetime - pd.Timedelta(hours=injection_before_hours)
                 window_end = injection_datetime + pd.Timedelta(hours=injection_after_hours)
                 start_offset = max((window_start - start_datetime).total_seconds(), 0)

--- a/pipeline_step3_merge.py
+++ b/pipeline_step3_merge.py
@@ -17,9 +17,11 @@ def merge_and_plot(
     comparison_mode="drug",
     comparison_drug="vehicle",
     mouse_groups_to_compare=None,
+    drug_names=None,
     quant_time_windows=None,
     config_path=None,
 ):
+    drug_names = drug_names or ["vehicle", "rapalog"]
     output_dir = Path(output_dir)
     if comparison_mode == "mouse_group" and mouse_groups_to_compare:
         compare_label = "_vs_".join(mouse_groups_to_compare)
@@ -44,6 +46,7 @@ def merge_and_plot(
         comparison_mode=comparison_mode,
         comparison_drug=comparison_drug,
         mouse_groups_to_compare=mouse_groups_to_compare,
+        drug_names=drug_names,
         quant_time_windows=quant_time_windows,
     )
 
@@ -58,8 +61,11 @@ def merge_and_plot(
         psd_df = pd.read_csv(psd_df)
         bout_df = pd.read_csv(bout_df)
 
-        for stage in ("NREM", "Wake", "REM"):
-            ana.wilcoxon_n_paried_t(stage_df, psd_df, bout_df, target_group, stage)
+        if len(drug_names) == 2:
+            for stage in ("NREM", "Wake", "REM"):
+                ana.wilcoxon_n_paried_t(stage_df, psd_df, bout_df, target_group, stage)
+        else:
+            print(f"[INFO] Skipping paired two-condition tests because drug_names has {len(drug_names)} conditions.")
 
     return merge_result
 
@@ -86,6 +92,12 @@ def main() -> None:
         nargs="*",
         default=None,
         help="Mouse groups to compare when comparison-mode is mouse_group (defaults to all groups found).",
+    )
+    parser.add_argument(
+        "--drug-names",
+        nargs="*",
+        default=None,
+        help="Drug conditions to compare in drug mode (e.g., vehicle drugA drugB).",
     )
     parser.add_argument("--output-dir", type=Path, required=True, help="Directory to store merged outputs")
     parser.add_argument("--config-path", type=Path, default=None, help="Optional config.json to copy into output dir")
@@ -114,6 +126,7 @@ def main() -> None:
         args.comparison_mode,
         args.comparison_drug,
         args.mouse_groups_to_compare,
+        args.drug_names,
         quant_time_windows,
         args.config_path,
     )

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -63,6 +63,7 @@ def ensure_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
         "comparison_mode": "drug",
         "comparison_drug": "vehicle",
         "mouse_groups_to_compare": [],
+        "drug_names": ["vehicle", "rapalog"],
         "output_dir": "/p-antipsychotics-sleep/figure/output",
         "epoch_len_sec": preprocess["epoch_len_sec"],
         "sample_freq": preprocess["sample_freq"],


### PR DESCRIPTION
### Motivation

- Allow the merge/analysis pipeline to support an arbitrary number of drug conditions (not just `vehicle` vs `rapalog`) and to control their ordering for plotting and analysis.
- Normalize drug names from `drug.info.csv` and allow variable-length `drugX_...` columns so experiments with 3+ conditions are handled.
- Expose the drug list via config/CLI so users can specify which conditions to include and in what order.

### Description

- Added `DEFAULT_DRUGS` and `_ordered_drug_list` in `analysis.py` and refactored PSD/stats merging functions to accept dictionaries/lists of drug names and per-drug subdirectory paths instead of hardcoded `vehicle`/`rapalog` paths.
- Made `merge_individual_df`, `meta_merge_psd_csv`, `process_stats_path_list`, and `process_psd_info_path_list` generic to handle multiple drugs and tag merged dataframes with the drug name index.
- Updated plotting functions (`plot_ts_1group`, `plot_PSD_1group`, `plot_PSD_1group_zoom`, `plot_bargraph`, etc.) to accept `drug_names`, draw lines/palettes for each drug, and preserve a consistent ordering; pairing lines between conditions are drawn only when exactly two ordered conditions are present.
- Updated `merge_n_plot` to accept and propagate `drug_names` and use ordered drug lists for plotting and PSD merging. Paired Wilcoxon tests are only executed when exactly two drug conditions are provided.
- Modified `pipeline_step2_analyze.py` to parse `drug.info.csv` flexibly by detecting `drug<N>_name` / `drug<N>_datetime` pairs, normalize drug names to lowercase, and parse datetimes robustly; removed the hardcoded filter that skipped non-vehicle/rapalog drugs so all listed drugs are analyzed.
- Added CLI support for `--drug-names` in `pipeline_step3_merge.py` and made `run_pipeline.py` and `pipeline.config.example.json` include `merge.drug_names` default values; updated `README.md` to document the new multi-condition workflow and examples.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ca89e3fed483318b6cf24b51856f08)