### PR TITLE
Allow datetime parsing without seconds

### DIFF
--- a/stage.py
+++ b/stage.py
@@ -529,11 +529,13 @@ def interpret_datetimestr(datetime_str):
                         r'(\d{4})/(\d{1,2})/(\d{1,2})',
                         r'(\d{4})-(\d{1,2})-(\d{1,2})']
 
-    timestr_patterns = [r'(\d{2})(\d{2})(\d{2})',
-                        r'(\d{1,2}):(\d{1,2}):(\d{1,2})',
-                        r'(\d{1,2})-(\d{1,2})-(\d{1,2})']
+    timestr_patterns = [r'(\d{1,2}):(\d{1,2})(?::(\d{1,2}))?',
+                        r'(\d{1,2})-(\d{1,2})(?:-(\d{1,2}))?',
+                        r'(?<!\d)(\d{2})(\d{2})(\d{2})(?!\d)',
+                        r'(?<!\d)(\d{2})(\d{2})(?!\d)']
 
     datetime_obj = None
+    datetime_str = str(datetime_str)
     for pat in datestr_patterns:
         matched = re.search(pat, datetime_str)
         if matched:
@@ -542,12 +544,16 @@ def interpret_datetimestr(datetime_str):
             day = int(matched.group(3))
             datetime_str = re.sub(pat, '', datetime_str)
 
+            matched_time = None
             for pat_time in timestr_patterns:
                 matched_time = re.search(pat_time, datetime_str)
                 if matched_time:
                     hour = int(matched_time.group(1))
                     minuite = int(matched_time.group(2))
-                    second = int(matched_time.group(3))
+                    second = int(
+                        matched_time.group(3)
+                        if matched_time.lastindex >= 3 and matched_time.group(3)
+                        else 0)
                     datetime_obj = datetime(year, month, day,
                                             hour, minuite, second)
                     break


### PR DESCRIPTION
### Motivation
- CSV metadata fields such as `Start datetime`, `End datetime`, and `drugX_datetime` sometimes omit seconds (e.g. `2025/12/02 17:00`), and the shared parser must treat missing seconds as `:00` so downstream code reads CSVs robustly.

### Description
- Updated the shared parser `interpret_datetimestr` in `stage.py` to accept hour:minute forms without seconds and to default missing seconds to `00` by making seconds optional in the time regexes and filling missing groups with `0`.
- Added handling for several compact and hyphen-delimited time formats (e.g. `HH:MM`, `YYYYMMDD HHMM`, `YYYY-MM-DD H-M`) while preserving existing support for `HH:MM:SS` and `HHMMSS` patterns.
- Coerced input to string early and guarded group access using `matched_time.lastindex` to avoid index errors when optional groups are absent.

### Testing
- Ran a small AST/execution smoke test that asserts `interpret_datetimestr` parses `2025/12/02 17:00`, `2025/12/02 17:00:30`, `2025-12-02 7-05`, and `20251202 1700` to the expected `datetime` values, and it passed.
- Verified the module compiles with `python -m py_compile stage.py` with no syntax errors.
- Performed lightweight runtime checks ensuring the parser still accepts time strings with and without seconds; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2268d24ba88331a4548e8016379e66)